### PR TITLE
Fix autoload Lang class

### DIFF
--- a/lib/Conekta.php
+++ b/lib/Conekta.php
@@ -12,7 +12,7 @@ if (!function_exists('mb_detect_encoding')) {
 if (!function_exists('get_called_class')) {
     throw new Exception('Conekta needs to be run on PHP >= 5.3.0.');
 }
-require_once dirname(__FILE__).'/locales/Lang.php';
+require_once dirname(__FILE__).'/Conekta/Lang.php';
 require_once dirname(__FILE__).'/Conekta/Conekta.php';
 require_once dirname(__FILE__).'/Conekta/Util.php';
 require_once dirname(__FILE__).'/Conekta/Requestor.php';

--- a/lib/Conekta/Lang.php
+++ b/lib/Conekta/Lang.php
@@ -9,7 +9,7 @@ class Conekta_Lang
 
     public static function translate($key, $parameters = null, $locale)
     {
-        $langs = self::readDirectory(dirname(__FILE__).'/messages');
+        $langs = self::readDirectory(dirname(__FILE__).'/../locales/messages');
 
         $keys = explode('.', $locale.'.'.$key);
         $result = $langs[array_shift($keys)];

--- a/test/Conekta/LangTest.php
+++ b/test/Conekta/LangTest.php
@@ -1,0 +1,17 @@
+<?php
+
+class Conekta_LangTest extends UnitTestCase
+{
+    public function testShouldTranslatesMessage()
+    {
+        $this->assertEqual(
+            'There was an error. Please contact system administrator.',
+            Conekta_Lang::translate('error.resource.id_purchaser', null, Conekta_Lang::EN)
+        );
+
+        $this->assertEqual(
+            'Hubo un error. Favor de contactar al administrador del sistema.',
+            Conekta_Lang::translate('error.resource.id_purchaser', null, Conekta_Lang::ES)
+        );
+    }
+}


### PR DESCRIPTION
Moved the Lang class to Conekta folder since it's being auto loaded on the composer.json and we get a `Fatal error: Class 'Conekta_Lang' not found`

https://github.com/conekta/conekta-php/blob/master/composer.json#L27

/cc @MauricioMurga 