### PR TITLE
Add array access to objects

### DIFF
--- a/lib/Conekta/Object.php
+++ b/lib/Conekta/Object.php
@@ -67,4 +67,9 @@ class Conekta_Object extends ArrayObject
     {
         return $this->__toJSON();
     }
+
+    public function offsetGet($offset)
+    {
+    	return isset($this->_values[$offset]) ? $this->_values[$offset] : null;
+    }
 }


### PR DESCRIPTION
/cc @MauricioMurga @leofischer This will give us access to objects values like arrays example:

```php
$data = Conekta_Event::where(['id' => $id])[0];

$data->type; // valid
$data['type']; // valid from this PR
```