### PR TITLE
Bump to php 5.3 version compat for namespaces

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -15,7 +15,7 @@
     }
   ],
   "require": {
-    "php": ">=5.2",
+    "php": ">=5.3",
     "ext-curl": "*",
     "ext-json": "*",
     "ext-mbstring": "*"


### PR DESCRIPTION
/cc @MauricioMurga @Janee Los namespaces en PHP sólo están disponibles desde la versión 5.3