### PR TITLE
Feature/delete payment source method

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -89,3 +89,7 @@
 * Multihandler exception
 * CamelCase convention over variables
 * Stable version of API 2.0.0.
+
+=== 3.4.0 2017-08-16
+
+* Header integration 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 ![README Cover Image](readme_cover.png)
 
-# Conekta PHP v.3.3.0
+# Conekta PHP v.3.4.0
 
 This is a php library that allows interaction with https://api.conekta.io API.
 
@@ -16,7 +16,7 @@ To get started, add the following to your PHP script:
 
 You can also install this library with composer:
 
-  require: "conekta/conekta-php": "3.3.0"
+  require: "conekta/conekta-php": "3.4.0"
 
 ## Usage
 

--- a/lib/Conekta/Conekta.php
+++ b/lib/Conekta/Conekta.php
@@ -10,7 +10,7 @@ abstract class Conekta
     public static $locale = 'es';
     public static $plugin = '';
     public static $pluginVersion = '';
-    const VERSION = '3.3.0';
+    const VERSION = '3.4.0';
 
     
     public static function setApiKey($apiKey)

--- a/lib/Conekta/Customer.php
+++ b/lib/Conekta/Customer.php
@@ -112,6 +112,22 @@ class Customer extends Resource
     return parent::_createMemberWithRelation('payment_sources', $params, $this);
   }
 
+  public function deletePaymentSource($paymentSourceId)
+  {
+    if (Conekta::$apiVersion == '2.0.0'){
+      $currentCustomer = $this;
+      $paymentSources = $currentCustomer->payment_sources;
+      $index = 0;
+      foreach ($paymentSources as $paymentSource) {
+        if ($paymentSource->id == $paymentSourceId){
+          $currentCustomer->payment_sources[$index]->delete();
+        }else{
+          $index += 1;
+        }
+      }
+    }
+  }
+
   public function createCard($params = null)
   {
     return parent::_createMemberWithRelation('cards', $params, $this);

--- a/lib/Conekta/Customer.php
+++ b/lib/Conekta/Customer.php
@@ -112,7 +112,7 @@ class Customer extends Resource
     return parent::_createMemberWithRelation('payment_sources', $params, $this);
   }
 
-  public function deletePaymentSource($paymentSourceId)
+  public function deletePaymentSourceById($paymentSourceId)
   {
     if (Conekta::$apiVersion == '2.0.0'){
       $currentCustomer = $this;

--- a/test/Conekta-2.0/CustomerTest.php
+++ b/test/Conekta-2.0/CustomerTest.php
@@ -79,7 +79,7 @@ class CustomerTest extends TestCase
       'type' => 'card'
       ));
     $customer->deletePaymentSource($customer->default_payment_source_id);
-    $this->assertTrue($customer->payment_sources->total == 0);
+    $this->assertTrue(strpos(get_class($customer->payment_sources), 'ConektaList') == false);
   }
 
   public function testSuccesfulShippingContactCreate()

--- a/test/Conekta-2.0/CustomerTest.php
+++ b/test/Conekta-2.0/CustomerTest.php
@@ -70,6 +70,17 @@ class CustomerTest extends TestCase
     $this->assertTrue(strpos(get_class($customer->payment_sources), 'ConektaList') !== false);
     $this->assertTrue($customer->payment_sources->total == 1);
   }
+  public function testSuccessfulSourceDelete()
+  {
+    $this->setApiKey();
+    $customer = \Conekta\Customer::create(self::$validCustomer);
+    $source = $customer->createPaymentSource(array(
+      'token_id' => 'tok_test_visa_4242',
+      'type' => 'card'
+      ));
+    $customer->deletePaymentSource($customer->default_payment_source_id);
+    $this->assertTrue($customer->payment_sources->total == 0);
+  }
 
   public function testSuccesfulShippingContactCreate()
   {

--- a/test/Conekta-2.0/CustomerTest.php
+++ b/test/Conekta-2.0/CustomerTest.php
@@ -74,12 +74,16 @@ class CustomerTest extends TestCase
   {
     $this->setApiKey();
     $customer = \Conekta\Customer::create(self::$validCustomer);
-    $source = $customer->createPaymentSource(array(
+    $firstSource = $customer->createPaymentSource(array(
       'token_id' => 'tok_test_visa_4242',
       'type' => 'card'
       ));
-    $customer->deletePaymentSource($customer->default_payment_source_id);
-    $this->assertTrue(strpos(get_class($customer->payment_sources), 'ConektaList') == false);
+    $secondSource = $customer->createPaymentSource(array(
+      'token_id' => 'tok_test_mastercard_4444',
+      'type' => 'card'
+      ));
+    $customer->deletePaymentSourceById($customer->payment_sources[1]->id);
+    $this->assertTrue($customer->payment_sources[1]->deleted);
   }
 
   public function testSuccesfulShippingContactCreate()


### PR DESCRIPTION
Caso de Uso:

Poder borrar un payment_source suponiendo tienen el payment_source_id almacenado en su base de datos.