### PR TITLE
Test: Use namespaces and change \Exception to Conekta handler

### DIFF
--- a/phpunit.xml
+++ b/phpunit.xml
@@ -1,0 +1,12 @@
+<phpunit bootstrap="test/bootstrap.php" colors="true">
+    <testsuites>
+        <testsuite name="Conekta PHP Test Suite">
+            <directory suffix="Test.php">tests</directory>
+        </testsuite>
+    </testsuites>
+    <filter>
+        <whitelist>
+            <directory>lib</directory>
+        </whitelist>
+    </filter>
+</phpunit>

--- a/test/BaseTest.php
+++ b/test/BaseTest.php
@@ -1,21 +1,23 @@
 <?php
 
-require_once dirname(__FILE__).'/../lib/Conekta.php';
+namespace Conekta;
 
-class BaseTest extends \PHPUnit\Framework\TestCase
+use \PHPUnit\Framework\TestCase;
+
+class BaseTest extends TestCase
 {
-  public function setApiKey()
-  {   
-    $apiEnvKey = getenv('CONEKTA_API');
-    if (!$apiEnvKey) {
-      $apiEnvKey = 'key_ZLy4aP2szht1HqzkCezDEA';
+    public function setApiKey()
+    {
+        $apiEnvKey = getenv('CONEKTA_API');
+        if (!$apiEnvKey) {
+            $apiEnvKey = 'key_ZLy4aP2szht1HqzkCezDEA';
+        }
+        Conekta::setApiKey($apiEnvKey);
     }
-    \Conekta\Conekta::setApiKey($apiEnvKey);
-  }
 
-  public function setApiVersion($version)
-  {
-    \Conekta\Conekta::setApiVersion($version);
-  }
-  
+    public function setApiVersion($version)
+    {
+        Conekta::setApiVersion($version);
+    }
+
 }

--- a/test/Conekta-1.0/ChargeTest.php
+++ b/test/Conekta-1.0/ChargeTest.php
@@ -1,9 +1,6 @@
 <?php
 
-use PHPUnit\Framework\TestCase;
-
-require_once dirname(__FILE__).'/../../lib/Conekta.php';
-require_once dirname(__FILE__).'/../BaseTest.php';
+namespace Conekta;
 
 class ChargeTest extends BaseTest
 {
@@ -71,7 +68,7 @@ class ChargeTest extends BaseTest
     {
         $this->setApiKey();
         $this->setApiVersion('1.0.0');
-        $charges = \Conekta\Charge::where();
+        $charges = Charge::where();
         $this->assertTrue(strpos(get_class($charges), 'ConektaObject') !== false);
         $this->assertTrue(strpos(get_class($charges[0]), 'Charge') !== false);
     }
@@ -83,8 +80,8 @@ class ChargeTest extends BaseTest
         $this->setApiKey();
         $this->setApiVersion('1.0.0');
         try {
-            $cpm = \Conekta\Charge::create(array_merge($pm, $card));
-        } catch (Exception $e) {
+            $cpm = Charge::create(array_merge($pm, $card));
+        } catch (Handler $e) {
             $this->assertTrue(strpos($e->getMessage(), 'The minimum for card payments is 3 pesos. Check that the amount is in cents as explained in the documentation.') !== false);
         }
     }
@@ -95,7 +92,7 @@ class ChargeTest extends BaseTest
         $pm = self::$valid_payment_method;
         $card = self::$valid_visa_card;
         $this->setApiKey();
-        $cpm = \Conekta\Charge::create(array_merge($pm, $card));
+        $cpm = Charge::create(array_merge($pm, $card));
         $this->assertTrue($cpm->status == 'paid');
         $cpm->refund();
         $this->assertTrue($cpm->status == 'refunded');
@@ -107,11 +104,11 @@ class ChargeTest extends BaseTest
         $card = self::$valid_visa_card;
         $this->setApiKey();
         $this->setApiVersion('1.0.0');
-        $cpm = \Conekta\Charge::create(array_merge($pm, $card));
+        $cpm = Charge::create(array_merge($pm, $card));
         $this->assertTrue($cpm->status == 'paid');
         try {
             $cpm->refund(3000);
-        } catch (Exception $e) {
+        } catch (Handler $e) {
             $this->assertTrue(strpos($e->getMessage(), 'The amount to refund exceeds the charge total') !== false);
         }
     }
@@ -123,7 +120,7 @@ class ChargeTest extends BaseTest
         $card = self::$valid_visa_card;
         $capture = array('capture' => false);
         $this->setApiKey();
-        $cpm = \Conekta\Charge::create(array_merge($pm, $card, $capture));
+        $cpm = Charge::create(array_merge($pm, $card, $capture));
         $this->assertTrue($cpm->status == 'pre_authorized');
         $cpm->capture();
         $this->assertTrue($cpm->status == 'paid');

--- a/test/Conekta-1.0/ConektaTest.php
+++ b/test/Conekta-1.0/ConektaTest.php
@@ -1,23 +1,21 @@
 <?php
-use PHPUnit\Framework\TestCase;
 
-require_once dirname(__FILE__).'/../../lib/Conekta.php';
-require_once dirname(__FILE__).'/../BaseTest.php';
+namespace Conekta;
 
 class ConektaTest extends BaseTest
 {
   function setPlugin($plugin){
-    \Conekta\Conekta::setPlugin($plugin);
+    Conekta::setPlugin($plugin);
   }
 
   function setEnvLocale($locale){
-    \Conekta\Conekta::setLocale($locale);
+    Conekta::setLocale($locale);
   }
 
   public function testApiLocaleInitializerStyle()
   {
     $this->setEnvLocale('en');
-    $this->assertTrue( \Conekta\Conekta::$locale == 'en');
+    $this->assertTrue( Conekta::$locale == 'en');
     $this->setEnvLocale('es');
   }
 
@@ -25,7 +23,7 @@ class ConektaTest extends BaseTest
   {
     $this->setApiKey();
     $this->setPlugin('spree');
-    $this->assertTrue( \Conekta\Conekta::$plugin == 'spree');
+    $this->assertTrue( Conekta::$plugin == 'spree');
   }
 
 }

--- a/test/Conekta-1.0/CustomerTest.php
+++ b/test/Conekta-1.0/CustomerTest.php
@@ -1,9 +1,6 @@
 <?php
 
-use PHPUnit\Framework\TestCase;
-
-require_once dirname(__FILE__).'/../../lib/Conekta.php';
-require_once dirname(__FILE__).'/../BaseTest.php';
+namespace Conekta;
 
 class CustomerTest extends BaseTest
 {
@@ -16,8 +13,8 @@ class CustomerTest extends BaseTest
   {
     $this->setApiKey();
     $this->setApiVersion('1.0.0');
-    $tmpCustomer = \Conekta\Customer::create(self::$validCustomer);
-    $customer = \Conekta\Customer::find($tmpCustomer->id);
+    $tmpCustomer = Customer::create(self::$validCustomer);
+    $customer = Customer::find($tmpCustomer->id);
     $this->assertTrue(strpos(get_class($customer), 'Customer') !== false);
   }
 
@@ -25,7 +22,7 @@ class CustomerTest extends BaseTest
   {
     $this->setApiKey();
     $this->setApiVersion('1.0.0');
-    $customers = \Conekta\Customer::where();
+    $customers = Customer::where();
     $this->assertTrue(strpos(get_class($customers), 'Object') !== false);
     $this->assertTrue(strpos(get_class($customers[0]), 'Customer') !== false);
   }
@@ -34,7 +31,7 @@ class CustomerTest extends BaseTest
   {
     $this->setApiKey();
     $this->setApiVersion('1.0.0');
-    $customer = \Conekta\Customer::create(self::$validCustomer);
+    $customer = Customer::create(self::$validCustomer);
     $customer->update(
       array(
         'name'  => 'Logan',
@@ -49,7 +46,7 @@ class CustomerTest extends BaseTest
   {
     $this->setApiKey();
     $this->setApiVersion('1.0.0');
-    $customer = \Conekta\Customer::create(self::$validCustomer);
+    $customer = Customer::create(self::$validCustomer);
     $customer->createCard(array('token' => 'tok_test_visa_1881'));
     $this->assertTrue(strpos(end($customer->cards)->last4, '1881') !== false);
   }
@@ -59,7 +56,7 @@ class CustomerTest extends BaseTest
     $this->setApiKey();
     $this->setApiVersion('1.0.0');
     $card = array('cards' => array('tok_test_visa_4242'));
-    $customer = \Conekta\Customer::create(array_merge(self::$validCustomer, $card));
+    $customer = Customer::create(array_merge(self::$validCustomer, $card));
     $card = $customer->cards[0]->delete();
     $this->assertTrue($card->deleted == true);
   }
@@ -69,7 +66,7 @@ class CustomerTest extends BaseTest
     $this->setApiKey();
     $this->setApiVersion('1.0.0');
     $card = array('cards' => array('tok_test_visa_4242'));
-    $customer = \Conekta\Customer::create(array_merge(self::$validCustomer, $card));
+    $customer = Customer::create(array_merge(self::$validCustomer, $card));
     $customer->cards[0]->update(array('token' => 'tok_test_mastercard_4444', 'active' => false));
     $this->assertTrue(strpos($customer->cards[0]->last4, '4444') !== false);    
   }
@@ -78,9 +75,9 @@ class CustomerTest extends BaseTest
   {
     $this->setApiKey();
     $this->setApiVersion('1.0.0');
-    $customer = \Conekta\Customer::create(self::$validCustomer);
+    $customer = Customer::create(self::$validCustomer);
     $card = array('cards' => array('tok_test_visa_4242'));
-    $customer = \Conekta\Customer::create(array_merge(self::$validCustomer, $card));
+    $customer = Customer::create(array_merge(self::$validCustomer, $card));
     $subscription = $customer->createSubscription(array('plan' => 'gold-plan'));
     $this->assertTrue(strpos(get_class($subscription), 'Conekta\Subscription') !== false);
   }
@@ -89,14 +86,14 @@ class CustomerTest extends BaseTest
   {
     $this->setApiKey();
     $this->setApiVersion('1.0.0');
-    $customer = \Conekta\Customer::create(self::$validCustomer);
+    $customer = Customer::create(self::$validCustomer);
     $card = array('cards' => array('tok_test_visa_4242'));
-    $customer = \Conekta\Customer::create(array_merge(self::$validCustomer, $card));
+    $customer = Customer::create(array_merge(self::$validCustomer, $card));
     $subscription = $customer->createSubscription(array('plan' => 'gold-plan'));
     try {
-      $plan = \Conekta\Plan::find('gold-plan2');
-    } catch (Exception $e) {
-      $plan = \Conekta\Plan::create(array(
+      $plan = Plan::find('gold-plan2');
+    } catch (Handler $e) {
+      $plan = Plan::create(array(
         'id'                => 'gold-plan2',
         'name'              => 'Gold Plan',
         'amount'            => 10000,
@@ -116,11 +113,11 @@ class CustomerTest extends BaseTest
   {
     $this->setApiKey();
     $this->setApiVersion('1.0.0');
-    $customer = \Conekta\Customer::create(self::$validCustomer);
+    $customer = Customer::create(self::$validCustomer);
     try {
       $subscription = $customer->createSubscription(array(
         'plan' => 'unexistent-plan', ));
-    } catch (Exception $e) {
+    } catch (Handler $e) {
       $this->assertTrue(strpos($e->getMessage(), 'The object Plan "unexistent-plan" could not be found.') !== false);
     }
   }
@@ -129,9 +126,9 @@ class CustomerTest extends BaseTest
   {
     $this->setApiKey();
     $this->setApiVersion('1.0.0');
-    $customer = \Conekta\Customer::create(self::$validCustomer);
+    $customer = Customer::create(self::$validCustomer);
     $card = array('cards' => array('tok_test_visa_4242'));
-    $customer = \Conekta\Customer::create(array_merge(self::$validCustomer, $card));
+    $customer = Customer::create(array_merge(self::$validCustomer, $card));
     $subscription = $customer->createSubscription(array('plan' => 'gold-plan'));
     $this->assertTrue(strpos(get_class($subscription), 'Subscription') !== false);
     $subscription->pause();
@@ -142,9 +139,9 @@ class CustomerTest extends BaseTest
   {
     $this->setApiKey();
     $this->setApiVersion('1.0.0');
-    $customer = \Conekta\Customer::create(self::$validCustomer);
+    $customer = Customer::create(self::$validCustomer);
     $card = array('cards' => array('tok_test_visa_4242'));
-    $customer = \Conekta\Customer::create(array_merge(self::$validCustomer, $card));
+    $customer = Customer::create(array_merge(self::$validCustomer, $card));
     $subscription = $customer->createSubscription(array('plan' => 'gold-plan'));
     $this->assertTrue(strpos(get_class($subscription), 'Subscription') !== false);
     $subscription->pause();
@@ -156,9 +153,9 @@ class CustomerTest extends BaseTest
   {
     $this->setApiKey();
     $this->setApiVersion('1.0.0');
-    $customer = \Conekta\Customer::create(self::$validCustomer);
+    $customer = Customer::create(self::$validCustomer);
     $card = array('cards' => array('tok_test_visa_4242'));
-    $customer = \Conekta\Customer::create(array_merge(self::$validCustomer, $card));
+    $customer = Customer::create(array_merge(self::$validCustomer, $card));
     $subscription = $customer->createSubscription(array('plan' => 'gold-plan'));
     $this->assertTrue(strpos(get_class($subscription), 'Subscription') !== false);
     $subscription->cancel();

--- a/test/Conekta-1.0/ErrorTest.php
+++ b/test/Conekta-1.0/ErrorTest.php
@@ -1,16 +1,13 @@
 <?php
 
-use PHPUnit\Framework\TestCase;
-
-require_once dirname(__FILE__).'/../../lib/Conekta.php';
-require_once dirname(__FILE__).'/../BaseTest.php';
+namespace Conekta;
 
 class ErrorTest extends BaseTest
 {   
   function unsetApiKey()
   {
     if (isset($env) == false) {
-      $env = \Conekta\Conekta::setApiKey('');
+      $env = Conekta::setApiKey('');
     }
   }
   public static $validOrder = array(
@@ -45,8 +42,8 @@ class ErrorTest extends BaseTest
   {
     $this->setApiKey();
     try {
-      $customer = \Conekta\Customer::find('0');
-    } catch (Exception $e) {
+      $customer = Customer::find('0');
+    } catch (Handler $e) {
       $this->assertTrue(strpos(get_class($e), 'ParameterValidationError') == true);
     }
   }
@@ -54,21 +51,21 @@ class ErrorTest extends BaseTest
   public function testNoConnectionError()
   {
     $this->setApiKey();
-    $apiUrl = \Conekta\Conekta::$apiBase;
-    \Conekta\Conekta::$apiBase = 'http://localhost:3001';
+    $apiUrl = Conekta::$apiBase;
+    Conekta::$apiBase = 'http://localhost:3001';
     try {
-      $customer = \Conekta\Customer::create(array('cards' => array('tok_test_visa_4241')));
-    } catch (Exception $e) {
+      $customer = Customer::create(array('cards' => array('tok_test_visa_4241')));
+    } catch (Handler $e) {
       $this->assertTrue(strpos(get_class($e), 'NoConnectionError') == true);
     }
-    \Conekta\Conekta::$apiBase = $apiUrl;
+    Conekta::$apiBase = $apiUrl;
   }
 
   public function testParameterValidationError(){
     $this->setApiKey();
     try {
-      $customer = \Conekta\Customer::create(self::$invalidCustomer);
-    } catch (Exception $e) {
+      $customer = Customer::create(self::$invalidCustomer);
+    } catch (Handler $e) {
       $this->assertTrue(strpos(get_class($e), 'ParameterValidationError') == true);
     }
   }
@@ -77,8 +74,8 @@ class ErrorTest extends BaseTest
   {
     $this->setApiKey();
     try {
-      $customer = \Conekta\Customer::find('2');
-    } catch (Exception $e) {
+      $customer = Customer::find('2');
+    } catch (Handler $e) {
       $this->assertTrue(strpos(get_class($e), 'ResourceNotFoundError') == true);
     }
   }
@@ -86,8 +83,8 @@ class ErrorTest extends BaseTest
   {
     $this->unsetApiKey();
     try {
-      $customer = \Conekta\Customer::create();
-    } catch (Exception $e){
+      $customer = Customer::create();
+    } catch (Handler $e){
       $this->assertTrue(strpos(get_class($e), 'AuthenticationError') == true);
     }
     $this->setApiKey();
@@ -103,9 +100,9 @@ class ErrorTest extends BaseTest
 
     try {
       $orderParams = array_merge(self::$validOrder, self::$otherParams);
-      $order  = \Conekta\Order::create($orderParams);
+      $order  = Order::create($orderParams);
       $charge = $order->createCharge($validVisaCard);
-    } catch (Exception $e){
+    } catch (Handler $e){
       $this->assertTrue(strpos(get_class($e), 'ResourceNotFoundError') == true);
     }
   }

--- a/test/Conekta-1.0/EventTest.php
+++ b/test/Conekta-1.0/EventTest.php
@@ -1,8 +1,6 @@
 <?php
-use PHPUnit\Framework\TestCase;
 
-require_once dirname(__FILE__).'/../../lib/Conekta.php';
-require_once dirname(__FILE__).'/../BaseTest.php';
+namespace Conekta;
 
 class EventTest extends BaseTest
 {
@@ -10,7 +8,7 @@ class EventTest extends BaseTest
 	{
 		$this->setApiKey();
 		$this->setApiVersion('1.0.0');
-		$events = \Conekta\Event::where();
+		$events = Event::where();
 		$this->assertTrue(strpos(get_class($events), 'Object') !== false);
 		$this->assertTrue(strpos(get_class($events[0]), 'Event') !== false);
 	}

--- a/test/Conekta-1.0/LangTest.php
+++ b/test/Conekta-1.0/LangTest.php
@@ -1,11 +1,8 @@
 <?php
 
-use \Conekta\Lang;
-use PHPUnit\Framework\TestCase;
+namespace Conekta;
 
-require_once dirname(__FILE__).'/../../lib/Conekta.php';
-
-class LangTest extends TestCase
+class LangTest extends BaseTest
 {   
 	public function testShouldTranslatesMessage()
 	{

--- a/test/Conekta-1.0/LogTest.php
+++ b/test/Conekta-1.0/LogTest.php
@@ -1,8 +1,6 @@
 <?php
-use PHPUnit\Framework\TestCase;
 
-require_once dirname(__FILE__).'/../../lib/Conekta.php';
-require_once dirname(__FILE__).'/../BaseTest.php';
+namespace Conekta;
 
 class LogTest extends BaseTest
 {
@@ -10,8 +8,8 @@ class LogTest extends BaseTest
   {
     $this->setApiKey();
     $this->setApiVersion('1.0.0');
-    $logs = \Conekta\Log::where();
-    $log = \Conekta\Log::find($logs[0]['id']);
+    $logs = Log::where();
+    $log = Log::find($logs[0]['id']);
     $this->assertTrue(strpos(get_class($log), 'Log') !== false);
   }
 
@@ -19,7 +17,7 @@ class LogTest extends BaseTest
   {
     $this->setApiKey();
     $this->setApiVersion('1.0.0');
-    $logs = \Conekta\Log::where();
+    $logs = Log::where();
     $this->assertTrue(strpos(get_class($logs), 'Conekta\ConektaObject') !== false);
     $this->assertTrue(strpos(get_class($logs[0]), 'Conekta\ConektaObject') !== false);
   }

--- a/test/Conekta-1.0/PayoutTest.php
+++ b/test/Conekta-1.0/PayoutTest.php
@@ -1,8 +1,6 @@
 <?php
-use PHPUnit\Framework\TestCase;
 
-require_once dirname(__FILE__).'/../../lib/Conekta.php';
-require_once dirname(__FILE__).'/../BaseTest.php';
+namespace Conekta;
 
 class PayoutTest extends BaseTest
 {
@@ -10,7 +8,7 @@ class PayoutTest extends BaseTest
   {
     $this->setApiKey();
     $this->setApiVersion('1.0.0');
-    $payee = \Conekta\Payee::create(array(
+    $payee = Payee::create(array(
       'name'  => 'John Doe',
       'email' => 'j_d@radcorp->com',
       'phone' => '555555555',
@@ -47,7 +45,7 @@ class PayoutTest extends BaseTest
     $this->assertTrue(strpos('tax121212abc', $payee->billing_address->tax_id) !== false);
     $this->assertTrue(strpos('06100', $payee->billing_address->zip) !== false);
 
-    $payout = \Conekta\Payout::create(array(
+    $payout = Payout::create(array(
       'amount'   => 5000,
       'currency' => 'MXN',
       'payee'    => $payee->id,

--- a/test/Conekta-1.0/PlanTest.php
+++ b/test/Conekta-1.0/PlanTest.php
@@ -1,8 +1,6 @@
 <?php
-use PHPUnit\Framework\TestCase;
 
-require_once dirname(__FILE__).'/../../lib/Conekta.php';
-require_once dirname(__FILE__).'/../BaseTest.php';
+namespace Conekta;
 
 class PlanTest extends BaseTest
 {
@@ -10,8 +8,8 @@ class PlanTest extends BaseTest
   {
     $this->setApiKey();
     $this->setApiVersion('1.0.0');
-    $plans = \Conekta\Plan::where();
-    $plan = \Conekta\Plan::find($plans[0]->id);
+    $plans = Plan::where();
+    $plan = Plan::find($plans[0]->id);
     $this->assertTrue(strpos(get_class($plan), 'Plan') !== false);
   }
 
@@ -19,7 +17,7 @@ class PlanTest extends BaseTest
   {
     $this->setApiKey();
     $this->setApiVersion('1.0.0');
-    $plans = \Conekta\Plan::where();
+    $plans = Plan::where();
     $this->assertTrue(strpos(get_class($plans), 'Object') !== false);
     $this->assertTrue(strpos(get_class($plans[0]), 'Plan') !== false);
   }
@@ -28,8 +26,8 @@ class PlanTest extends BaseTest
   {
     $this->setApiKey();
     $this->setApiVersion('1.0.0');
-    $plans = \Conekta\Plan::where();
-    $plan = \Conekta\Plan::create(array(
+    $plans = Plan::where();
+    $plan = Plan::create(array(
       'id'                => 'gold-plan'.substr('abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ', mt_rand(0, 50), 1).substr(md5(time()), 1),
       'name'              => 'Gold Plan',
       'amount'            => 10000,
@@ -46,7 +44,7 @@ class PlanTest extends BaseTest
   {
     $this->setApiKey();
     $this->setApiVersion('1.0.0');
-    $plans = \Conekta\Plan::where();
+    $plans = Plan::where();
     $plan = $plans[0];
     $plan->update(array('name' => 'Silver Plan'));
     $this->assertTrue(strpos($plan->name, 'Silver Plan') !== false);
@@ -56,7 +54,7 @@ class PlanTest extends BaseTest
   {
     $this->setApiKey();
     $this->setApiVersion('1.0.0');
-    $plans = \Conekta\Plan::where();
+    $plans = Plan::where();
     $plan = $plans[0];
     $plan->delete();
     $this->assertTrue($plan->deleted == true);

--- a/test/Conekta-1.0/WebhookTest.php
+++ b/test/Conekta-1.0/WebhookTest.php
@@ -1,8 +1,6 @@
 <?php
-use PHPUnit\Framework\TestCase;
 
-require_once dirname(__FILE__).'/../../lib/Conekta.php';
-require_once dirname(__FILE__).'/../BaseTest.php';
+namespace Conekta;
 
 class WebhookTest extends BaseTest
 {
@@ -26,7 +24,7 @@ class WebhookTest extends BaseTest
   {
     $this->setApiKey();
     $this->setApiVersion('1.0.0');
-    $webhook = \Conekta\Webhook::create(array_merge(self::$url, self::$events));
+    $webhook = Webhook::create(array_merge(self::$url, self::$events));
     $this->assertTrue(strpos(get_class($webhook), 'Webhook') !== false);
     $this->assertTrue(strpos($webhook->webhook_url, self::$url["url"]) !== false);
     $webhook->update(array("url" => "http://www.example.com/my_listener"));

--- a/test/Conekta-2.0/ChargeTest.php
+++ b/test/Conekta-2.0/ChargeTest.php
@@ -1,9 +1,6 @@
 <?php
 
-use PHPUnit\Framework\TestCase;
-
-require_once dirname(__FILE__).'/../../lib/Conekta.php';
-require_once dirname(__FILE__).'/../BaseTest.php';
+namespace Conekta;
 
 class ChargeTest extends BaseTest
 {
@@ -40,7 +37,7 @@ class ChargeTest extends BaseTest
   {
     $this->setApiKey();
     $orderParams = array_merge(self::$validOrder, self::$otherParams);
-    $order = \Conekta\Order::create($orderParams);
+    $order = Order::create($orderParams);
     $this->assertTrue(strpos(get_class($order), 'Order') !== false);
     
     return $order;
@@ -50,7 +47,7 @@ class ChargeTest extends BaseTest
   {
     $order  = $this->testCreateOrder(); 
     $charge = $order->createCharge(self::$chargeParams);
-    $filterCharges = \Conekta\Order::find($charge->id);
+    $filterCharges = Order::find($charge->id);
     $validCharge = $filterCharges->charges[0];
     $this->assertTrue(strpos(get_class($validCharge), 'Charge') !== false);
   }

--- a/test/Conekta-2.0/ConektaListTest.php
+++ b/test/Conekta-2.0/ConektaListTest.php
@@ -1,16 +1,13 @@
 <?php
 
-use PHPUnit\Framework\TestCase;
-
-require_once dirname(__FILE__).'/../../lib/Conekta.php';
-require_once dirname(__FILE__).'/../BaseTest.php';
+namespace Conekta;
 
 class ConektaListTest extends BaseTest
 {
   public function testSuccessfulNext()
   {
     $orderList = $this->createResponseMockUp();
-    $window = \Conekta\Order::where(array('limit' => 5, "next" => $orderList[9]->id)); 
+    $window = Order::where(array('limit' => 5, "next" => $orderList[9]->id));
     $this->assertTrue($window[0]->id == $orderList[10]->id);
     $window->next(array('limit' => 1));
     $this->assertTrue($window[0]->id == $orderList[15]->id);
@@ -19,7 +16,7 @@ class ConektaListTest extends BaseTest
   public function testSuccessfulPrevious()
   {
     $orderList = $this->createResponseMockUp();
-    $window = \Conekta\Order::where(array('limit' => 5, 'next' => $orderList[14]->id));
+    $window = Order::where(array('limit' => 5, 'next' => $orderList[14]->id));
     $this->assertTrue($window[0]->id == $orderList[15]->id);
     $window->previous(array('limit' => 1));
     $this->assertTrue($window[0]->id == $orderList[14]->id);
@@ -32,7 +29,7 @@ class ConektaListTest extends BaseTest
     $path = file_exists($overRootFolder) ? $overRootFolder: $insideTestFolder;
     $object        = file_get_contents($path);
     $jsonResponse  = json_decode($object, true);
-    $orderList     = new \Conekta\ConektaList("Order", $jsonResponse);
+    $orderList     = new ConektaList("Order", $jsonResponse);
     $orderList->loadFromArray($jsonResponse);
     
     return $orderList;
@@ -40,7 +37,7 @@ class ConektaListTest extends BaseTest
   public function testSuccessfulEmptyNext()
   {
     $orderList = $this->createResponseMockUp();
-    $window = \Conekta\Order::where(array('limit' => 5));
+    $window = Order::where(array('limit' => 5));
 
     $firtsOrderId = $window[0]->id;
     $window->next(); 
@@ -62,7 +59,7 @@ class ConektaListTest extends BaseTest
   public function testSuccessfulEmptyPrevious()
   {
     $orderList = $this->createResponseMockUp();
-    $window = \Conekta\Order::where(array('limit' => 10)); 
+    $window = Order::where(array('limit' => 10));
 
     $firtsOrderId = $window[0]->id;
     $window->next(); 

--- a/test/Conekta-2.0/ConektaTest.php
+++ b/test/Conekta-2.0/ConektaTest.php
@@ -1,27 +1,24 @@
 <?php
  
-use PHPUnit\Framework\TestCase;
-
-require_once dirname(__FILE__).'/../../lib/Conekta.php';
-require_once dirname(__FILE__).'/../BaseTest.php';
+namespace Conekta;
 
 class ConektaTest extends BaseTest
 {
 
   function setEnvLocale($locale){
-    \Conekta\Conekta::setLocale($locale);
+    Conekta::setLocale($locale);
   }
   function setPlugin($plugin){
-    \Conekta\Conekta::setPlugin($plugin);
+    Conekta::setPlugin($plugin);
   }
   function setPluginVersion($version){
-    \Conekta\Conekta::setPluginVersion($version);
+    Conekta::setPluginVersion($version);
   }
 
   public function testApiLocaleInitializerStyle()
   {
     $this->setEnvLocale('en');
-    $this->assertTrue( \Conekta\Conekta::$locale == 'en');
+    $this->assertTrue( Conekta::$locale == 'en');
     $this->setEnvLocale('es');
   }
 
@@ -30,8 +27,8 @@ class ConektaTest extends BaseTest
     $this->setApiKey();
     $this->setPlugin('Magento 2');
     $this->setPluginVersion('2.0.0');
-    $this->assertTrue( \Conekta\Conekta::getPlugin() == 'Magento 2');
-    $this->assertTrue( \Conekta\Conekta::getPluginVersion() == '2.0.0');
+    $this->assertTrue( Conekta::getPlugin() == 'Magento 2');
+    $this->assertTrue( Conekta::getPluginVersion() == '2.0.0');
   }
 
 }

--- a/test/Conekta-2.0/CustomerTest.php
+++ b/test/Conekta-2.0/CustomerTest.php
@@ -1,9 +1,6 @@
 <?php
 
-use PHPUnit\Framework\TestCase;
-
-require_once dirname(__FILE__).'/../../lib/Conekta.php';
-require_once dirname(__FILE__).'/../BaseTest.php';
+namespace Conekta;
 
 class CustomerTest extends BaseTest
 {
@@ -19,14 +16,14 @@ class CustomerTest extends BaseTest
   public function testSuccesfulCustomerCreate()
   {
     $this->setApiKey();
-    $customer = \Conekta\Customer::create(self::$validCustomer);
+    $customer = Customer::create(self::$validCustomer);
     $this->assertTrue(strpos(get_class($customer), 'Customer') !== false);
   }
 
   public function testSuccessfulCustomerNewWhere()
   {
     $this->setApiKey();
-    $customers = \Conekta\Customer::where();
+    $customers = Customer::where();
     $this->assertTrue(strpos(get_class($customers), 'ConektaList') !== false);
     $this->assertTrue(strpos($customers->elements_type, 'Customer') !== false);
     $this->assertTrue(strpos(get_class($customers[0]), 'Customer') !== false);
@@ -36,7 +33,7 @@ class CustomerTest extends BaseTest
   public function testSuccesfulDeleteCustomer()
   {
     $this->setApiKey();
-    $customer = \Conekta\Customer::create(self::$validCustomer);
+    $customer = Customer::create(self::$validCustomer);
     $customer->delete();
     $this->assertTrue($customer->deleted == true);
   }
@@ -45,8 +42,8 @@ class CustomerTest extends BaseTest
   {
     $this->setApiKey();
     try {
-      $customer = \Conekta\Customer::create(self::$invalidCustomer);
-    } catch (\Conekta\ParameterValidationError $e) {
+      $customer = Customer::create(self::$invalidCustomer);
+    } catch (ParameterValidationError $e) {
       $this->assertTrue(strpos($e->getMessage(),"El parametro \"name\" es requerido") !== false);
     }
   }
@@ -54,7 +51,7 @@ class CustomerTest extends BaseTest
   public function testSuccesfulSourceCreate()
   {
     $this->setApiKey();
-    $customer = \Conekta\Customer::create(self::$validCustomer);
+    $customer = Customer::create(self::$validCustomer);
     $source = $customer->createPaymentSource(array(
       'token_id' => 'tok_test_visa_4242',
       'type' => 'card'
@@ -66,7 +63,7 @@ class CustomerTest extends BaseTest
   public function testSuccessfulSourceDelete()
   {
     $this->setApiKey();
-    $customer = \Conekta\Customer::create(self::$validCustomer);
+    $customer = Customer::create(self::$validCustomer);
     $firstSource = $customer->createPaymentSource(array(
       'token_id' => 'tok_test_visa_4242',
       'type' => 'card'
@@ -82,7 +79,7 @@ class CustomerTest extends BaseTest
   public function testSuccesfulShippingContactCreate()
   {
     $this->setApiKey();
-    $customer = \Conekta\Customer::create(self::$validCustomer);
+    $customer = Customer::create(self::$validCustomer);
     $shippingContact = $customer->createShippingContact(array(
       'receiver' => 'John Williams',
       'phone' => '+523333350360',

--- a/test/Conekta-2.0/DiscountLineTest.php
+++ b/test/Conekta-2.0/DiscountLineTest.php
@@ -1,9 +1,6 @@
 <?php
 
-use PHPUnit\Framework\TestCase;
-
-require_once dirname(__FILE__).'/../../lib/Conekta.php';
-require_once dirname(__FILE__).'/../BaseTest.php';
+namespace Conekta;
 
 class DiscountLineTest extends BaseTest
 {
@@ -38,7 +35,7 @@ class DiscountLineTest extends BaseTest
   public function testSuccessfulDiscountLineDelete()
   {
     $this->setApiKey();
-    $order = \Conekta\Order::create(self::$validOrder);
+    $order = Order::create(self::$validOrder);
     $discountLine = $order->discount_lines[0];
     $discountLine->delete();
 
@@ -48,7 +45,7 @@ class DiscountLineTest extends BaseTest
   public function testSuccessfulDiscountLineUpdate()
   {
     $this->setApiKey();
-    $order = \Conekta\Order::create(self::$validOrder);
+    $order = Order::create(self::$validOrder);
     $discountLine = $order->discount_lines[0];
     $discountLine->update(array('amount' => 11));
 
@@ -58,11 +55,11 @@ class DiscountLineTest extends BaseTest
   public function testUnsuccessfulDiscountLineUpdate()
   {
     $this->setApiKey();
-    $order = \Conekta\Order::create(self::$validOrder);
+    $order = Order::create(self::$validOrder);
     $discountLine = $order->discount_lines[0];
     try{
       $discountLine->update(array('amount' => -1));
-    } catch(\Conekta\Handler $e) {
+    } catch(Handler $e) {
       $this->assertTrue(strpos(get_class($e), 'ParameterValidationError') == true);
     }
   }

--- a/test/Conekta-2.0/ErrorHandlerTest.php
+++ b/test/Conekta-2.0/ErrorHandlerTest.php
@@ -1,9 +1,6 @@
 <?php
 
-use PHPUnit\Framework\TestCase;
-
-require_once dirname(__FILE__).'/../../lib/Conekta.php';
-require_once dirname(__FILE__).'/../BaseTest.php';
+namespace Conekta;
 
 class ErrorHandlerTest extends BaseTest
 {   
@@ -39,7 +36,7 @@ class ErrorHandlerTest extends BaseTest
   function unsetApiKey()
   {
     if (isset($env) == false) {
-      $env = \Conekta\Conekta::setApiKey('');
+      $env = Conekta::setApiKey('');
     }
   }
 
@@ -47,8 +44,8 @@ class ErrorHandlerTest extends BaseTest
   {
     $this->setApiKey();
     try {
-      $customer = \Conekta\Customer::find('0');
-    } catch (Exception $e) {
+      $customer = Customer::find('0');
+    } catch (Handler $e) {
       $this->assertTrue(strpos(get_class($e), 'ParameterValidationError') == true);
     }
   }
@@ -56,21 +53,21 @@ class ErrorHandlerTest extends BaseTest
   public function testNoConnectionError()
   {
     $this->setApiKey();
-    $apiUrl = \Conekta\Conekta::$apiBase;
-    \Conekta\Conekta::$apiBase = 'http://localhost:3001';
+    $apiUrl = Conekta::$apiBase;
+    Conekta::$apiBase = 'http://localhost:3001';
     try {
-      $customer = \Conekta\Customer::create(array('cards' => array('tok_test_visa_4241')));
-    } catch (Exception $e) {
+      $customer = Customer::create(array('cards' => array('tok_test_visa_4241')));
+    } catch (Handler $e) {
       $this->assertTrue(strpos(get_class($e), 'NoConnectionError') == true);
     }
-    \Conekta\Conekta::$apiBase = $apiUrl;
+    Conekta::$apiBase = $apiUrl;
   }
 
   public function testParameterValidationError(){
     $this->setApiKey();
     try {
-      $customer = \Conekta\Customer::create(self::$invalidCustomer);
-    } catch (Exception $e) {
+      $customer = Customer::create(self::$invalidCustomer);
+    } catch (Handler $e) {
       $this->assertTrue(strpos(get_class($e), 'ParameterValidationError') == true);
     }
   }
@@ -79,8 +76,8 @@ class ErrorHandlerTest extends BaseTest
   {
     $this->setApiKey();
     try {
-      $customer = \Conekta\Customer::find('2');
-    } catch (Exception $e) {
+      $customer = Customer::find('2');
+    } catch (Handler $e) {
       $this->assertTrue(strpos(get_class($e), 'ResourceNotFoundError') == true);
     }
   }
@@ -88,8 +85,8 @@ class ErrorHandlerTest extends BaseTest
   {
     $this->unsetApiKey();
     try{
-      $customer = \Conekta\Customer::create();
-    }catch(Exception $e){
+      $customer = Customer::create();
+    }catch(Handler $e){
       $this->assertTrue(strpos(get_class($e), 'AuthenticationError') == true);
     }
     $this->setApiKey();
@@ -105,9 +102,9 @@ class ErrorHandlerTest extends BaseTest
 
     try{
       $orderParams = array_merge(self::$validOrder, self::$otherParams);
-      $order  = \Conekta\Order::create($orderParams);
+      $order  = Order::create($orderParams);
       $charge = $order->createCharge($valid_visa_card);
-    }catch(Exception $e){
+    }catch(Handler $e){
       $this->assertTrue(strpos(get_class($e), 'ProcessingError') == true);
     }
   }

--- a/test/Conekta-2.0/LangTest.php
+++ b/test/Conekta-2.0/LangTest.php
@@ -1,11 +1,8 @@
 <?php
 
-use \Conekta\Lang;
-use PHPUnit\Framework\TestCase;
+namespace Conekta;
 
-require_once dirname(__FILE__).'/../../lib/Conekta.php';
-
-class LangTest extends TestCase
+class LangTest extends BaseTest
 {   
 	public function testShouldTranslatesMessage()
 	{

--- a/test/Conekta-2.0/LineItemTest.php
+++ b/test/Conekta-2.0/LineItemTest.php
@@ -1,9 +1,6 @@
 <?php
 
-use PHPUnit\Framework\TestCase;
-
-require_once dirname(__FILE__).'/../../lib/Conekta.php';
-require_once dirname(__FILE__).'/../BaseTest.php';
+namespace Conekta;
 
 class LineItemTest extends BaseTest
 {   
@@ -31,7 +28,7 @@ class LineItemTest extends BaseTest
   public function testSuccessfulLineItemDelete()
   {
     $this->setApiKey();
-    $order = \Conekta\Order::create(self::$validOrder);
+    $order = Order::create(self::$validOrder);
     $lineItem = $order->line_items[0];
     $lineItem->delete();
 
@@ -41,7 +38,7 @@ class LineItemTest extends BaseTest
   public function testSuccessfulLineItemUpdate()
   {
     $this->setApiKey();
-    $order = \Conekta\Order::create(self::$validOrder);
+    $order = Order::create(self::$validOrder);
     $lineItem = $order->line_items[0];
     $lineItem->update(array('unit_price' => 1000));
 
@@ -51,12 +48,12 @@ class LineItemTest extends BaseTest
   public function testUnsuccessfulLineItemUpdate()
   {
     $this->setApiKey();
-    $order = \Conekta\Order::create(self::$validOrder);
+    $order = Order::create(self::$validOrder);
     $lineItem = $order->line_items[0];
     try {
       $lineItem->update(array('unit_price' => -1));
 
-    } catch(\Conekta\Handler $e) {
+    } catch(Handler $e) {
       $this->assertTrue(strpos(get_class($e), 'ParameterValidationError') == true);
     }
   }

--- a/test/Conekta-2.0/OrderTest.php
+++ b/test/Conekta-2.0/OrderTest.php
@@ -1,9 +1,6 @@
 <?php
 
-use PHPUnit\Framework\TestCase;
-
-require_once dirname(__FILE__).'/../../lib/Conekta.php';
-require_once dirname(__FILE__).'/../BaseTest.php';
+namespace Conekta;
 
 class OrderTest extends BaseTest
 {
@@ -33,7 +30,7 @@ class OrderTest extends BaseTest
   public function testSuccesfulCreateOrder()
   {
     $this->setApiKey();
-    $order = \Conekta\Order::create(self::$validOrder);
+    $order = Order::create(self::$validOrder);
     $this->assertTrue(strpos($order->metadata["test"], 'extra info') !== false);
     $this->assertTrue(strpos(get_class($order), 'Order') !== false);
 
@@ -59,7 +56,7 @@ class OrderTest extends BaseTest
         )
       );
     $this->setApiKey();
-    $order = \Conekta\Order::create(array_merge(self::$validOrder, $charges));
+    $order = Order::create(array_merge(self::$validOrder, $charges));
     $this->assertTrue(strpos(get_class($order), 'Order') !== false);
     $this->assertTrue(count($order->charges) > 0);
   }
@@ -76,7 +73,7 @@ class OrderTest extends BaseTest
         )
       );
     $this->setApiKey();
-    $order = \Conekta\Order::create(array_merge(self::$validOrder, $other_params));
+    $order = Order::create(array_merge(self::$validOrder, $other_params));
     $charge_params = array(
       'payment_method' => array('type' => 'oxxo_cash'),
       'amount' => 20000
@@ -91,7 +88,7 @@ class OrderTest extends BaseTest
   public function testSuccesfulOrderUpdate()
   {
     $this->setApiKey();
-    $order = \Conekta\Order::create(self::$validOrder);
+    $order = Order::create(self::$validOrder);
 
     $updated_parameters = array(
       'line_items'=> array(
@@ -124,10 +121,10 @@ class OrderTest extends BaseTest
       );
 
     $this->setApiKey();
-    $order = \Conekta\Order::create(self::$validOrder);
+    $order = Order::create(self::$validOrder);
     try {
       $order->update(array('charges' => $charges));
-    } catch(\Conekta\Handler $e) {
+    } catch(Handler $e) {
       $this->assertTrue(strpos(get_class($e), 'ParameterValidationError') == true);
     }
   }
@@ -135,15 +132,15 @@ class OrderTest extends BaseTest
   public function testSuccesfulOrderFind()
   {
     $this->setApiKey();
-    $id = \Conekta\Order::create(self::$validOrder)->id;
-    $order = \Conekta\Order::find($id);
+    $id = Order::create(self::$validOrder)->id;
+    $order = Order::find($id);
     $this->assertTrue(strpos(get_class($order), 'Order') !== false);
   }
 
   public function testSuccesfulOrderWhere()
   {
     $this->setApiKey();
-    $orders = \Conekta\Order::where();
+    $orders = Order::where();
     $this->assertTrue(strpos(get_class($orders), 'ConektaList') !== false);
     $this->assertTrue(strpos($orders->elements_type, 'Order') !== false);
     $this->assertTrue(strpos(get_class($orders[0]), 'Order') !== false);
@@ -153,7 +150,7 @@ class OrderTest extends BaseTest
   public function testSuccessfulLineItem()
   {
     $this->setApiKey();
-    $order = \Conekta\Order::create(self::$validOrder);
+    $order = Order::create(self::$validOrder);
 
     $line_item = $order->createLineItem(array(
       'name'=> 'Box of Cohiba S1s',
@@ -171,7 +168,7 @@ class OrderTest extends BaseTest
   public function testSuccessfulTaxLine()
   {
     $this->setApiKey();
-    $order = \Conekta\Order::create(self::$validOrder);
+    $order = Order::create(self::$validOrder);
 
     $taxLine = $order->createTaxLine(array(
       'description' => 'IVA',
@@ -191,7 +188,7 @@ class OrderTest extends BaseTest
   public function testSuccessfulShippingLine()
   {
     $this->setApiKey();
-    $order = \Conekta\Order::create(self::$validOrder);
+    $order = Order::create(self::$validOrder);
 
     $shippingLine = $order->createShippingLine(array(
       'description' => 'Free Shipping',
@@ -209,7 +206,7 @@ class OrderTest extends BaseTest
   public function testSuccessfulDiscountLine()
   {
     $this->setApiKey();
-    $order = \Conekta\Order::create(self::$validOrder);
+    $order = Order::create(self::$validOrder);
     $discountLine = $order->createDiscountLine(array(
       'code' => 'Cupon de descuento',
       'amount' => 10,
@@ -240,9 +237,9 @@ class OrderTest extends BaseTest
         )
       );
     $this->setApiKey();
-    $order = \Conekta\Order::create(array_merge(self::$validOrder, $charges));
+    $order = Order::create(array_merge(self::$validOrder, $charges));
     $order->refund(array_merge(self::$validRefund, array('order_id' => $order->id)));
-    $refundedOrder = \Conekta\Order::find($order->id);
+    $refundedOrder = Order::find($order->id);
 
     $this->assertTrue($refundedOrder->payment_status == 'refunded');
   }
@@ -269,7 +266,7 @@ class OrderTest extends BaseTest
         )
       );
     $this->setApiKey();
-    $order = \Conekta\Order::create(array_merge(self::$validOrder, $charges));
+    $order = Order::create(array_merge(self::$validOrder, $charges));
     $this->assertTrue($order->payment_status == 'pre_authorized');
     $this->assertTrue($order->charges[0]->status == 'pre_authorized');
 

--- a/test/Conekta-2.0/ShippingContactTest.php
+++ b/test/Conekta-2.0/ShippingContactTest.php
@@ -1,9 +1,6 @@
 <?php
 
-use PHPUnit\Framework\TestCase;
-
-require_once dirname(__FILE__).'/../../lib/Conekta.php';
-require_once dirname(__FILE__).'/../BaseTest.php';
+namespace Conekta;
 
 class ShippingContactTest extends BaseTest
 {
@@ -40,7 +37,7 @@ class ShippingContactTest extends BaseTest
   public function testSuccessfulShippingContactDelete()
   {
     $this->setApiKey();
-    $customer = \Conekta\Customer::create(self::$validCustomer);
+    $customer = Customer::create(self::$validCustomer);
     $shippingContact = $customer->shipping_contacts[0];
     $shippingContact->delete();
     $this->assertTrue($shippingContact->deleted == true);
@@ -49,7 +46,7 @@ class ShippingContactTest extends BaseTest
   public function testSuccessfulShippingContactUpdate()
   {
     $this->setApiKey();
-    $customer = \Conekta\Customer::create(self::$validCustomer);
+    $customer = Customer::create(self::$validCustomer);
     $shippingContact = $customer->shipping_contacts[0];
     $shippingContact->update(array('receiver' => 'Tony Almeida'));
     $this->assertTrue($shippingContact->receiver == 'Tony Almeida');
@@ -58,11 +55,11 @@ class ShippingContactTest extends BaseTest
   public function testUnsuccessfulShippingContactUpdate()
   {
     $this->setApiKey();
-    $customer = \Conekta\Customer::create(self::$validCustomer);
+    $customer = Customer::create(self::$validCustomer);
     $shippingContact = $customer->shipping_contacts[0];
     try{
       $shippingContact->update(array('phone' => ''));
-    }catch (Exception $e) {
+    }catch (Handler $e) {
 
       $this->assertTrue(strpos(get_class($e), 'ParameterValidationError') == true);
     }

--- a/test/Conekta-2.0/ShippingLineTest.php
+++ b/test/Conekta-2.0/ShippingLineTest.php
@@ -1,9 +1,6 @@
 <?php
 
-use PHPUnit\Framework\TestCase;
-
-require_once dirname(__FILE__).'/../../lib/Conekta.php';
-require_once dirname(__FILE__).'/../BaseTest.php';
+namespace Conekta;
 
 class ShippingLineTest extends BaseTest
 {
@@ -42,7 +39,7 @@ class ShippingLineTest extends BaseTest
   public function testSuccessfulShippingLineDelete()
   {
     $this->setApiKey();
-    $order = \Conekta\Order::create(self::$validOrder);
+    $order = Order::create(self::$validOrder);
     $shippingLine = $order->shipping_lines[0];
     $shippingLine->delete();
     $this->assertTrue($shippingLine->deleted == true);
@@ -51,7 +48,7 @@ class ShippingLineTest extends BaseTest
   public function testSuccessfulShippingLineUpdate()
   {
     $this->setApiKey();
-    $order = \Conekta\Order::create(self::$validOrder);
+    $order = Order::create(self::$validOrder);
     $shippingLine = $order->shipping_lines[0];
     $shippingLine->update(array('method' => 'Air'));
     $this->assertTrue($shippingLine->method == 'Air');
@@ -60,11 +57,11 @@ class ShippingLineTest extends BaseTest
   public function testUnsuccessfulShippingLineUpdate()
   {
     $this->setApiKey();
-    $order = \Conekta\Order::create(self::$validOrder);
+    $order = Order::create(self::$validOrder);
     $shippingLine = $order->shipping_lines[0];
     try{
       $shippingLine->update(array('amount' => -1));
-    } catch (Exception $e) {
+    } catch (Handler $e) {
       $this->assertTrue(strpos(get_class($e), 'ParameterValidationError') == true);
     }
   }

--- a/test/Conekta-2.0/SourceTest.php
+++ b/test/Conekta-2.0/SourceTest.php
@@ -1,9 +1,6 @@
 <?php
 
-use PHPUnit\Framework\TestCase;
-
-require_once dirname(__FILE__).'/../../lib/Conekta.php';
-require_once dirname(__FILE__).'/../BaseTest.php';
+namespace Conekta;
 
 class SourceTest extends BaseTest
 {
@@ -19,7 +16,7 @@ class SourceTest extends BaseTest
   public function testSuccesfulDeleteSources()
   {
     $this->setApiKey();
-    $customer = \Conekta\Customer::create(self::$validCustomer);
+    $customer = Customer::create(self::$validCustomer);
     $paymentSource = $customer->payment_sources[0];
     $paymentSource->delete();
     $this->assertTrue($paymentSource->deleted == true);
@@ -28,7 +25,7 @@ class SourceTest extends BaseTest
   public function testSuccesfulUpdateSources()
   {
     $this->setApiKey();
-    $customer = \Conekta\Customer::create(self::$validCustomer);
+    $customer = Customer::create(self::$validCustomer);
     $paymentSource = $customer->payment_sources[0];
     $paymentSource->update(array('exp_month' => '11'));
     $this->assertTrue($paymentSource->exp_month == '11');
@@ -36,11 +33,11 @@ class SourceTest extends BaseTest
 
   public function testUnsuccesfulUpdateSources(){
     $this->setApiKey();
-    $customer = \Conekta\Customer::create(self::$validCustomer);
+    $customer = Customer::create(self::$validCustomer);
     $paymentSource = $customer->payment_sources[0];
     try{
       $paymentSource->update(array('token_id' => 'tok_test_visa_4241'));
-    }catch (Exception $e) {
+    }catch (Handler $e) {
       $this->assertTrue(strpos(get_class($e), 'ParameterValidationError') == true);
     }
   }

--- a/test/Conekta-2.0/SubscriptionTest.php
+++ b/test/Conekta-2.0/SubscriptionTest.php
@@ -1,8 +1,6 @@
 <?php 
-use PHPUnit\Framework\TestCase;
 
-require_once dirname(__FILE__).'/../../lib/Conekta.php';
-require_once dirname(__FILE__).'/../BaseTest.php';
+namespace Conekta;
 
 class SubscriptionTest extends BaseTest
 {
@@ -15,7 +13,7 @@ class SubscriptionTest extends BaseTest
   public function testSuccesfulSubscriptionCreate()
   {
     $this->setApiKey();
-    $customer = \Conekta\Customer::create(self::$validCustomer);
+    $customer = Customer::create(self::$validCustomer);
     $customer->createPaymentSource(self::$validVisaCard);
     $subscription = $customer->createSubscription(array('plan' => 'gold-plan'));
     $this->assertTrue(strpos(get_class($subscription), 'Conekta\Subscription') !== false);
@@ -24,13 +22,13 @@ class SubscriptionTest extends BaseTest
   public function testSuccesfulSubscriptionUpdate()
   {
     $this->setApiKey();
-    $customer = \Conekta\Customer::create(self::$validCustomer);
+    $customer = Customer::create(self::$validCustomer);
     $customer->createPaymentSource(self::$validVisaCard);
     $subscription = $customer->createSubscription(array('plan' => 'gold-plan'));
     try {
-      $plan = \Conekta\Plan::find('gold-plan2');
-    } catch (Exception $e) {
-      $plan = \Conekta\Plan::create(array(
+      $plan = Plan::find('gold-plan2');
+    } catch (Handler $e) {
+      $plan = Plan::create(array(
         'id'                => 'gold-plan2',
         'name'              => 'Gold Plan',
         'amount'            => 10000,
@@ -49,12 +47,12 @@ class SubscriptionTest extends BaseTest
   public function testUnsuccesfulSubscriptionCreate()
   {
     $this->setApiKey();
-    $customer = \Conekta\Customer::create(self::$validCustomer);
+    $customer = Customer::create(self::$validCustomer);
     $customer->createPaymentSource(self::$validVisaCard);
     try {
       $subscription = $customer->createSubscription(array(
         'plan' => 'unexistent-plan', ));
-    } catch (Exception $e) {
+    } catch (Handler $e) {
       $this->assertTrue(strpos($e->getMessage(), 'El recurso no ha sido encontrado') !== false);
     }
   }
@@ -62,7 +60,7 @@ class SubscriptionTest extends BaseTest
   public function testSuccesfulSubscriptionPause()
   {
     $this->setApiKey();
-    $customer = \Conekta\Customer::create(self::$validCustomer);
+    $customer = Customer::create(self::$validCustomer);
     $customer->createPaymentSource(self::$validVisaCard);
     $subscription = $customer->createSubscription(array('plan' => 'gold-plan'));
     $this->assertTrue(strpos(get_class($subscription), 'Subscription') !== false);
@@ -73,7 +71,7 @@ class SubscriptionTest extends BaseTest
   public function testSuccesfulSubscriptionResume()
   {
     $this->setApiKey();
-    $customer = \Conekta\Customer::create(self::$validCustomer);
+    $customer = Customer::create(self::$validCustomer);
     $customer->createPaymentSource(self::$validVisaCard);
     $subscription = $customer->createSubscription(array('plan' => 'gold-plan'));
     $this->assertTrue(strpos(get_class($subscription), 'Subscription') !== false);
@@ -85,7 +83,7 @@ class SubscriptionTest extends BaseTest
   public function testSuccesfulSubscriptionCancel()
   {
     $this->setApiKey();
-    $customer = \Conekta\Customer::create(self::$validCustomer);
+    $customer = Customer::create(self::$validCustomer);
     $customer->createPaymentSource(self::$validVisaCard);
     $subscription = $customer->createSubscription(array('plan' => 'gold-plan'));
     $this->assertTrue(strpos(get_class($subscription), 'Subscription') !== false);

--- a/test/Conekta-2.0/TaxLineTest.php
+++ b/test/Conekta-2.0/TaxLineTest.php
@@ -1,9 +1,6 @@
 <?php
 
-use PHPUnit\Framework\TestCase;
-
-require_once dirname(__FILE__).'/../../lib/Conekta.php';
-require_once dirname(__FILE__).'/../BaseTest.php';
+namespace Conekta;
 
 class TaxLineTest extends BaseTest
 {
@@ -36,7 +33,7 @@ class TaxLineTest extends BaseTest
   public function testSuccessfulTaxLineDelete()
   {
     $this->setApiKey();
-    $order = \Conekta\Order::create(self::$validOrder);
+    $order = Order::create(self::$validOrder);
     $taxLine = $order->tax_lines[0];
     $taxLine->delete();
     $this->assertTrue($taxLine->deleted == true);
@@ -45,7 +42,7 @@ class TaxLineTest extends BaseTest
   public function testSuccessfulTaxLineUpdate()
   {
     $this->setApiKey();
-    $order = \Conekta\Order::create(self::$validOrder);
+    $order = Order::create(self::$validOrder);
     $taxLine = $order->tax_lines[0];
     $taxLine->update(array('amount' => 10));
     $this->assertTrue($taxLine->amount == 10);
@@ -54,11 +51,11 @@ class TaxLineTest extends BaseTest
   public function testUnsuccessfulTaxLineUpdate()
   {
     $this->setApiKey();
-    $order = \Conekta\Order::create(self::$validOrder);
+    $order = Order::create(self::$validOrder);
     $taxLine = $order->tax_lines[0];
     try {
       $taxLine->update(array('amount' => -1));
-    } catch (Exception $e) {
+    } catch (Handler $e) {
       $this->assertTrue(strpos(get_class($e), 'ParameterValidationError') == true);
     }
   }

--- a/test/Conekta-2.0/WebhookTest.php
+++ b/test/Conekta-2.0/WebhookTest.php
@@ -1,9 +1,6 @@
 <?php
 
-use PHPUnit\Framework\TestCase;
-
-require_once dirname(__FILE__).'/../../lib/Conekta.php';
-require_once dirname(__FILE__).'/../BaseTest.php';
+namespace Conekta;
 
 class WebhookTest extends BaseTest
 {
@@ -26,7 +23,7 @@ class WebhookTest extends BaseTest
   public function testSuccesfulWebhookCreate()
   {
     $this->setApiKey();
-    $webhook = \Conekta\Webhook::create(array_merge(self::$url, self::$events));
+    $webhook = Webhook::create(array_merge(self::$url, self::$events));
     $this->assertTrue(strpos(get_class($webhook), 'Webhook') !== false);
     $this->assertTrue(strpos($webhook->webhook_url, self::$url["url"]) !== false);
     $webhook->update(array("url" => "http://www.example.com/my_listener"));

--- a/test/bootstrap.php
+++ b/test/bootstrap.php
@@ -1,0 +1,4 @@
+
+<?php
+require_once __DIR__ . '/../lib/Conekta.php';
+require_once __DIR__ . '/BaseTest.php';


### PR DESCRIPTION
Refactor in tests:
- Use namespace Conekta
- Use Conekta exceptions in tests 
- Remove unused imports and vars

![captura de pantalla 2017-09-13 a la s 11 30 44](https://user-images.githubusercontent.com/17298066/30390021-57416574-987a-11e7-91aa-dfd39034941c.png)
