### PR TITLE
Tests for oxxo recurrent source.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## [4.0.2](https://github.com/conekta/conekta-php/releases/tag/v4.0.1) - 2018-03-22
+### Feature
+- Support to Oxxo recurrent
+
 ## [4.0.1](https://github.com/conekta/conekta-php/releases/tag/v4.0.1) - 2017-12-29
 ### Feature
 - Implement void action for orders

--- a/composer.json
+++ b/composer.json
@@ -15,13 +15,13 @@
     }
   ],
   "require": {
-    "php": ">=5.3",
+    "php": "~7.0",
     "ext-curl": "*",
     "ext-json": "*",
     "ext-mbstring": "*"
   },
   "require-dev": {
-    "phpunit/phpunit": "*"
+    "phpunit/phpunit": "~6.1"
   },
   "autoload": {
     "classmap": ["lib/Conekta/"]

--- a/lib/Conekta/PaymentSource.php
+++ b/lib/Conekta/PaymentSource.php
@@ -9,6 +9,9 @@ use \Conekta\Conekta;
 
 class PaymentSource extends ConektaResource
 {
+  const TYPE_CARD = 'card';
+  const TYPE_OXXO_RECURRENT = 'oxxo_recurrent';
+
   public function instanceUrl()
   {
     $this->apiVersion = Conekta::$apiVersion;
@@ -31,4 +34,23 @@ class PaymentSource extends ConektaResource
   {
     return parent::_delete('customer', 'payment_sources');
   }
+
+  /**
+   * Method for determine if is card
+   * @return boolean
+   */
+  public function isCard()
+  {
+    return $this['type'] == self::TYPE_CARD;
+  }
+
+  /**
+   * Method for determine if is oxxo recurrent
+   * @return boolean
+   */
+  public function isOxxoRecurrent()
+  {
+    return $this['type'] == self::TYPE_OXXO_RECURRENT;
+  }
+
 }


### PR DESCRIPTION
Why is this change neccesary?

For the php version is needed support to oxxo recurrent.

How does it address the issue?

Validate oxxo recurrent is working.

What side effects does this change have?

Nothing.