### PR TITLE
Verificar que no se pase null a get_class

### DIFF
--- a/lib/Conekta/ConektaResource.php
+++ b/lib/Conekta/ConektaResource.php
@@ -148,7 +148,8 @@ abstract class ConektaResource extends ConektaObject
     $url = $this->instanceUrl().'/'.$member;
     $response = $requestor->request('post', $url, $params);
 
-    if (strpos(get_class($this->$member), 'ConektaList') !== false ||
+    if (is_null($this->$member) ||
+      strpos(get_class($this->$member), 'ConektaList') !== false ||
       strpos(get_class($this->$member), 'ConektaObject') !== false ||
       strpos($member, 'cards') !== false ||
       strpos($member, 'payout_methods') !== false) {


### PR DESCRIPTION
Ya que desde php 7.2 pasar null a get_class produce un error E_WARNING.

Fixes #113