### PR TITLE
 Feature: Force to use TLSv1.2

### DIFF
--- a/lib/Conekta/Requestor.php
+++ b/lib/Conekta/Requestor.php
@@ -140,6 +140,7 @@ class Requestor
     $opts[CURLOPT_TIMEOUT] = 80;
     $opts[CURLOPT_RETURNTRANSFER] = true;
     $opts[CURLOPT_HTTPHEADER] = $headers;
+    $opts[CURLOPT_SSLVERSION] = 6;
     $opts[CURLOPT_CAINFO] = dirname(__FILE__).'/../ssl_data/ca_bundle.crt';
     curl_setopt_array($curl, $opts);
     $response = curl_exec($curl);


### PR DESCRIPTION
**Why is this change neccesary?**
in order to have compliance with the latest security standards to keep communication our libraries wiht our api 
**How does it address the issue?**
forcing  to curl library to set up tls v1.2 as mandatory
**What side effects does this change have?**
nothing 
resource 
https://community.developer.visa.com/t5/Developer-Tools/Upgrade-to-TLS-1-2-Let-security-be-part-of-your-development/ba-p/6691