### PR TITLE
Feature: Add reference parameter to PHP SDK

### DIFF
--- a/test/Conekta-2.0/CustomerTest.php
+++ b/test/Conekta-2.0/CustomerTest.php
@@ -12,6 +12,14 @@ class CustomerTest extends BaseTest
     'email' => 'hola@hola.com',
     'names'  => 'John Constantine'
     );
+  public static $validRecurrentCustomerWithCustomReference = array(
+    'name' => 'Rick Sanchez',
+    'email' => 'rick.sanchez@conekta.com',
+    'payment_sources' => array(array(
+      'type' => 'oxxo_recurrent',
+      'reference' => '5512345678'
+    ))
+  );
   public static $validRecurrentCustomer = array(
     'name' => 'John Constantine',
     'email' => 'john_constantine@conekta.com',
@@ -121,7 +129,30 @@ class CustomerTest extends BaseTest
     $this->assertTrue(strlen($source['reference']) == 14);
   }
 
-   public function testCustomerWithOfflineRecurrentSourceIsCreated()
+  public function testCustomerWithCustomReference()
+  {
+    $this->markTestIncomplete('Not ready yet');
+    $this->setApiKey();
+    Customer::create(self::$validRecurrentCustomerWithCustomReference);
+    $this->assertEquals($source['type'], 'oxxo_recurrent');
+    $this->assertTrue(strlen($source['reference']) == 10);
+    $this->assertEquals($source['reference'], '5512345678');
+  }
+
+  public function testAddCustomReferenceToCustomer()
+  {
+    $this->markTestIncomplete();
+    $this->setApiKey();
+    $customer = Customer::create(self::$validCustomer);
+    $source = $customer->createOfflineRecurrentReference(array(
+      'type' => 'oxxo_recurrent',
+      'reference' => '5587654321'
+    ));
+    $this->assertTrue(strlen($source['reference']) == 10);
+    $this->assertEquals($source['reference'], '5587654321');
+  }
+
+  public function testCustomerWithOfflineRecurrentSourceIsCreated()
   {
     $this->setApiKey();
     $customer = Customer::create(self::$validRecurrentCustomer);


### PR DESCRIPTION
#### Why is this change necessary?

Payments API currently is taking custom fixed references from merchants
customer create request

#### How does it address the issue?

It's necessary to test that the custom reference is not created by
Conekta when the customer sends the reference in a request

#### What side effects does this have?

Tests related to this feature are skipped because none of the merchants
have offline recurrent identifier which is needed to test this
feature