### PR TITLE
More intelligent verification of unset list fields

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -15,13 +15,13 @@
     }
   ],
   "require": {
-    "php": "~7.0",
+    "php": ">=7.1",
     "ext-curl": "*",
     "ext-json": "*",
     "ext-mbstring": "*"
   },
   "require-dev": {
-    "phpunit/phpunit": "~6.1"
+    "phpunit/phpunit": "~7"
   },
   "autoload": {
     "classmap": ["lib/Conekta/"]


### PR DESCRIPTION
Adding defensive logic to properly load null lists and not throw an error if they are blank.  Additionally, we raise the required version to 7.1 and test for compatibility with 7.2 and 7.3.

This is linked to issue https://github.com/conekta/conekta-php/issues/113.