### PR TITLE
Upgrade/php 7.4

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,5 +8,6 @@ composer.lock
 INSTALL.txt
 LICENSE.txt
 README.txt
+.phpunit.result.cache
 demos/
 extras/documentation

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## [4.2.0](https://github.com/conekta/conekta-php/releases/tag/v4.2.0) - 2020-01-15
+### Feature
+- Fixing specs for PHP 7.4
+### Deprecating end(ConektaList)
+- Certain array functions (such as end) are no longer working as expected for ConektaList in PHP 7.4, though count, [] and each continue to be supported
+
 ## [4.1.0](https://github.com/conekta/conekta-php/releases/tag/v4.1.0) - 2019-12-31
 ### Feature
 - Correcting subscriptions errors in PHP 7.1+

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 ![banner](readme_files/banner.png)
 
-# Conekta PHP v.4.1.0
+# Conekta PHP
 
 ![php badge](readme_files/php-badge.png)
 ![conekta badge](readme_files/conekta-badge.png)
@@ -13,7 +13,7 @@ This is a PHP library that allows interaction with [Conekta's API](https://api.c
 
 ## Requeriments
 
-PHPUnit 6.1 requires PHP 7; using the latest version of PHP is highly recommended.
+PHPUnit ~8 requires PHP 7.2+; using the latest version of PHP is highly recommended.
 
 ## Installation
 
@@ -27,7 +27,7 @@ To get started, add the following to your PHP script:
 
 You can also install this library with [Composer](https://github.com/composer/composer):
 
-    require: "conekta/conekta-php": "4.1.0"
+    require: "conekta/conekta-php": "4.2.0"
 
 ## Usage
 
@@ -89,23 +89,23 @@ Unit test based on PHP library [PHPUnit](https://github.com/sebastianbergmann/ph
 For better usage install PHPUnit globally:
 
 ```bash
-$ wget https://phar.phpunit.de/phpunit-6.1.phar
+$ wget https://phar.phpunit.de/phpunit-8.5.2.phar
 
-$ chmod +x phpunit-6.1.phar
+$ chmod +x phpunit-8.5.2.phar
 
-$ sudo mv phpunit-6.1.phar /usr/local/bin/phpunit
+$ sudo mv phpunit-8.5.2.phar /usr/local/bin/phpunit
 
 $ phpunit --version
 
 ej. output
-PHPUnit 6.1.1 by Sebastian Bergmann and contributors.
+PHPUnit 8.5.2 by Sebastian Bergmann and contributors.
 
 ```
 
 PHP version used
 
 ```
-PHP 7.0.17 (cli)
+PHP 7.4.24 (cli)
 ```
 
 Run test suite:
@@ -114,9 +114,9 @@ Run test suite:
 phpunit test/Conekta-x.0
 ```
 
-_note:_ for this PHPUnit version (6.1.x) only PHP 7 is supported for older PHP versions see PHPunit <a href="https://phpunit.de/"> documentation</a>
+_note:_ for this PHPUnit version (8.x) only PHP 7.2+ is supported for older PHP versions see PHPunit <a href="https://phpunit.de/"> documentation</a>
 
-## Changelong
+## Changelog
 
 Please see [CHANGELOG](CHANGELOG.md) for more information what has changed recently.
 

--- a/composer.json
+++ b/composer.json
@@ -15,13 +15,13 @@
     }
   ],
   "require": {
-    "php": ">=7.1",
+    "php": ">=7.2",
     "ext-curl": "*",
     "ext-json": "*",
     "ext-mbstring": "*"
   },
   "require-dev": {
-    "phpunit/phpunit": "~7"
+    "phpunit/phpunit": "~8"
   },
   "autoload": {
     "classmap": ["lib/Conekta/"]

--- a/lib/Conekta/Conekta.php
+++ b/lib/Conekta/Conekta.php
@@ -10,7 +10,7 @@ abstract class Conekta
     public static $locale = 'es';
     public static $plugin = '';
     public static $pluginVersion = '';
-    const VERSION = '4.1.0';
+    const VERSION = '4.2.0';
 
     
     public static function setApiKey($apiKey)

--- a/lib/Conekta/ConektaList.php
+++ b/lib/Conekta/ConektaList.php
@@ -24,8 +24,9 @@ class ConektaList extends ConektaObject
   public function addElement($element)
   {
     $element = Util::convertToConektaObject($element);
-    $this[$this->total] = $element;
-    $this->_values[$this->total] = $element;
+    $array_length = count($this->_values);
+    $this[$array_length] = $element;
+    $this->_values[$array_length] = $element;
     $this->total = $this->total + 1;
 
     return $this;

--- a/lib/Conekta/ConektaResource.php
+++ b/lib/Conekta/ConektaResource.php
@@ -180,7 +180,7 @@ abstract class ConektaResource extends ConektaObject
         $this->loadFromArray();
       }
       $instances = $this->$member;
-      $instance = end($instances);
+      $instance = $instances[count($instances) - 1];
     } else {
       $class = '\\Conekta\\' . ucfirst($member);
 

--- a/test/Conekta-1.0/CustomerTest.php
+++ b/test/Conekta-1.0/CustomerTest.php
@@ -48,7 +48,7 @@ class CustomerTest extends BaseTest
     $this->setApiVersion('1.0.0');
     $customer = Customer::create(self::$validCustomer);
     $customer->createCard(array('token' => 'tok_test_visa_1881'));
-    $this->assertTrue(strpos(end($customer->cards)->last4, '1881') !== false);
+    $this->assertTrue(strpos($customer->cards[0]->last4, '1881') !== false);
   }
 
   public function testDeleteCard()


### PR DESCRIPTION
Fixes an issue related to failing specs for ConektaList objects in PHP 7.4.

PHP 7.4 has introduced an open issue related to array iteration (`end()`) for ConektaList which will likely require conekta-php interface changes and will be postponed for a future release.