### PR TITLE
PAYM-1296  eliminar columna needs multifactor authenticator

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## [4.3.0](https://github.com/conekta/conekta-php/releases/tag/v4.3.0) - 2020-07-07
+### Feature
+- Add models to support payment link (aka checkout).
+
 ## [4.2.0](https://github.com/conekta/conekta-php/releases/tag/v4.2.0) - 2020-01-15
 ### Feature
 - Fixing specs for PHP 7.4

--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ To get started, add the following to your PHP script:
 
 You can also install this library with [Composer](https://github.com/composer/composer):
 
-    require: "conekta/conekta-php": "4.2.0"
+    require: "conekta/conekta-php": "4.3.0"
 
 ## Usage
 

--- a/lib/Conekta.php
+++ b/lib/Conekta.php
@@ -42,6 +42,7 @@ require_once dirname(__FILE__).'/Conekta/ShippingLine.php';
 require_once dirname(__FILE__).'/Conekta/LineItem.php';
 require_once dirname(__FILE__).'/Conekta/ConektaList.php';
 require_once dirname(__FILE__).'/Conekta/ShippingContact.php';
+require_once dirname(__FILE__).'/Conekta/Checkout.php';
 require_once dirname(__FILE__).'/Conekta/Exceptions/Handler.php';
 require_once dirname(__FILE__).'/Conekta/Exceptions/ApiError.php';
 require_once dirname(__FILE__).'/Conekta/Exceptions/AuthenticationError.php';

--- a/lib/Conekta/Checkout.php
+++ b/lib/Conekta/Checkout.php
@@ -1,0 +1,66 @@
+<?php
+
+namespace Conekta;
+
+use \Conekta\ConektaResource;
+
+class Checkout extends ConektaResource
+{
+
+  public function __get($property)
+  {
+    if (property_exists($this, $property)) {
+      return $this->$property;
+    }
+  }
+
+  public function  __isset($property)
+  {
+    return isset($this->$property);
+  }
+
+  public function loadFromArray($values = null)
+  {
+    if (isset($values)) {
+      parent::loadFromArray($values);
+    }
+  }
+
+  public static function find($id)
+  {
+    $class = get_called_class();
+
+    return parent::_scpFind($class, $id);
+  }
+
+  public static function where($params = null)
+  {
+    $class = get_called_class();
+
+    return parent::_scpWhere($class, $params);
+  }
+
+  public static function create($params = null)
+  {
+    $class = get_called_class();
+
+    return parent::_scpCreate($class, $params);
+  }
+
+  public function sendEmail($params = null)
+  {
+    return parent::_customAction('post', 'email', $params);
+  }
+
+  public function sendSms($params = null)
+  {
+    return parent::_customAction('post', 'sms', $params);
+  }
+
+  public static function all($params = null)
+  {
+    $class = get_called_class();
+
+    return parent::_scpWhere($class, $params);
+  }
+}

--- a/lib/Conekta/Conekta.php
+++ b/lib/Conekta/Conekta.php
@@ -10,39 +10,43 @@ abstract class Conekta
     public static $locale = 'es';
     public static $plugin = '';
     public static $pluginVersion = '';
-    const VERSION = '4.2.0';
+    const VERSION = '4.3.0';
 
-    
+    public static function setApiBase($apiBase)
+    {
+        self::$apiBase = $apiBase;
+    }
+
     public static function setApiKey($apiKey)
     {
         self::$apiKey = $apiKey;
     }
-    
+
     public static function setApiVersion($version)
     {
         self::$apiVersion = $version;
     }
-    
+
     public static function setLocale($locale)
     {
         self::$locale = $locale;
     }
-    
+
     public static function setPlugin($plugin = '')
     {
         self::$plugin = $plugin;
     }
-    
+
     public static function setPluginVersion($pluginVersion = '')
     {
         self::$pluginVersion = $pluginVersion;
     }
-    
+
     public static function getPlugin()
     {
         return self::$plugin;
     }
-    
+
     public static function getPluginVersion()
     {
         return self::$pluginVersion;

--- a/lib/Conekta/ConektaResource.php
+++ b/lib/Conekta/ConektaResource.php
@@ -126,7 +126,7 @@ abstract class ConektaResource extends ConektaObject
             break;
           }
         }
-      } 
+      }
     }
 
     return $this;
@@ -214,7 +214,7 @@ abstract class ConektaResource extends ConektaObject
     $parent_class = strtolower((new \ReflectionClass($parent))->getShortName());
     $child = self::_createMember($member, $params);
     $child->$parent_class = $parent;
-    
+
     return $child;
   }
 }

--- a/lib/Conekta/Requestor.php
+++ b/lib/Conekta/Requestor.php
@@ -80,7 +80,7 @@ class Requestor
     if(array_filter($pluginAgent)){
       $userAgent = array_merge($userAgent, $pluginAgent);
     }
-    
+
     $headers = array(
       'Accept: application/vnd.conekta-v'.Conekta::$apiVersion.'+json',
       'Accept-Language: '.Conekta::$locale,
@@ -96,11 +96,11 @@ class Requestor
   /**
    * Function request
    *
-   * Make api call 
+   * Make api call
    *
    * @param method (string) REST action [DELETE,PUT,POST,GET]
    * @param url (string) endpoint to concatenate
-   * @param params (array) contains body request 
+   * @param params (array) contains body request
    * @return (json)
    */
   public function request($method, $url, $params = null)
@@ -159,7 +159,7 @@ class Requestor
   /**
    * Function buildQueryParamsUrl
    *
-   * build body request into url 
+   * build body request into url
    *
    * @param url (string) endpoint to concatenate
    * @param params (array) contains body request

--- a/lib/Conekta/Util.php
+++ b/lib/Conekta/Util.php
@@ -32,7 +32,8 @@ abstract class Util
     'lang'                        => '\Conekta\Lang',
     'line_item'                   => '\Conekta\LineItem',
     'order'                       => '\Conekta\Order',
-    'token'                       => '\Conekta\Token'
+    'token'                       => '\Conekta\Token',
+    'checkout'                    => '\Conekta\Checkout',
     );
 
   public static function convertToConektaObject($resp)

--- a/test/BaseTest.php
+++ b/test/BaseTest.php
@@ -12,6 +12,10 @@ class BaseTest extends TestCase
         if (!$apiEnvKey) {
             $apiEnvKey = 'key_ZLy4aP2szht1HqzkCezDEA';
         }
+        $apiBase = getenv('CONEKTA_API_BASE');
+        if ($apiBase) {
+            Conekta::setApiBase($apiBase);
+        }
         Conekta::setApiKey($apiEnvKey);
     }
 

--- a/test/Conekta-2.0/CheckoutTest.php
+++ b/test/Conekta-2.0/CheckoutTest.php
@@ -1,0 +1,104 @@
+<?php
+
+namespace Conekta;
+
+class CheckoutTest extends BaseTest
+{
+  public static $validCheckout = array(
+      'name' => "Payment Link Name",
+      'type' => "PaymentLink",
+      'recurrent' => false,
+      'allowed_payment_methods' => array("cash", "card", "bank_transfer"),
+      'needs_shipping_contact' => false,
+      'order_template' => array(
+        'line_items' => array(array(
+          'name' => "Red Wine",
+          'unit_price' => 1000,
+          'quantity' => 10
+        )),
+        'metadata' => array(
+          'mycustomkey' => "12345",
+          'othercustomkey' => "abcd"
+        ),
+        'currency' => "MXN",
+        'customer_info' => array(
+          'name' => "Juan Perez",
+          'email' => "juan.perez@conekta.com",
+          'phone' => "5566982090"
+        )
+      )
+    );
+  public static $invalidCheckout = array(
+    'names'  => 'John Constantine'
+  );
+
+  public function testSuccesfulCheckoutCreate()
+  {
+    $this->setApiKey();
+    self::$validCheckout['name'] = 'Payment Link Name ' . time();
+    self::$validCheckout['expired_at'] = static::getExpiredAt();
+    $checkout = Checkout::create(self::$validCheckout);
+    $this->assertTrue(strpos(get_class($checkout), 'Checkout') !== false);
+    $this->assertEquals(false, $checkout->livemode);
+    $this->assertEquals(self::$validCheckout['name'], $checkout->name);
+    $this->assertEquals(false, $checkout->needs_shipping_contact);
+    $this->assertStringStartsWith("https://pay.conekta", $checkout->url);
+    $this->assertStringEndsWith($checkout->slug, $checkout->url);
+    $this->assertTrue(strlen($checkout->id) == 36);
+
+    return $checkout;
+  }
+
+  public function testSuccessfulCheckoutNewWhere()
+  {
+    $this->setApiKey();
+    $checkouts = Checkout::where();
+    $this->assertTrue(strpos(get_class($checkouts), 'ConektaList') !== false);
+    $this->assertTrue(strpos($checkouts->elements_type, 'Checkout') !== false);
+    $this->assertEquals('Conekta\Checkout', get_class($checkouts[0]));
+    $this->assertEquals('Conekta\Checkout', get_class(end($checkouts)));
+  }
+
+  public function testSuccesfulFindCheckout()
+  {
+    $checkout  = $this->testSuccesfulCheckoutCreate();
+    $filterCheckout = Checkout::find($checkout->id);
+    $this->assertTrue(strpos(get_class($filterCheckout), 'Checkout') !== false);
+  }
+
+  public function testSuccesfulSendEmail()
+  {
+    $checkout  = $this->testSuccesfulCheckoutCreate();
+    $checkout->sendEmail(array('email' => 'mail@mail.com'));
+
+    $this->assertTrue(strpos(get_class($checkout), 'Checkout') !== false);
+    $this->assertEquals(1, $checkout->emails_sent);
+  }
+
+  public function testUnsuccesfulSendSms()
+  {
+    $checkout  = $this->testSuccesfulCheckoutCreate();
+    try {
+      $checkout->sendSms(array('phone' => '555555555'));
+    } catch (\Exception $e) {
+      $this->assertTrue(strpos($e->getMessage(),"Las notificaciones sms no estan activas.") !== false);
+    }
+  }
+
+  public function testUnsuccesfulCheckoutCreate()
+  {
+    $this->setApiKey();
+    try {
+      $checkout = Checkout::create(self::$invalidCheckout);
+    } catch (\Exception $e) {
+      $this->assertTrue(strpos($e->getMessage(),"El parametro \"order_template\" es requerido") !== false);
+    }
+  }
+
+  public static function getExpiredAt()
+  {
+    $datetime = new \Datetime();
+    $datetime->add(new \DateInterval('P3D'));
+    return $datetime->format('U');
+  }
+}

--- a/test/Conekta-2.0/CheckoutTest.php
+++ b/test/Conekta-2.0/CheckoutTest.php
@@ -90,6 +90,8 @@ class CheckoutTest extends BaseTest
     $this->assertStringStartsWith("https://pay.conekta", $checkout->url);
     $this->assertStringEndsWith($checkout->slug, $checkout->url);
     $this->assertTrue(strlen($checkout->id) == 36);
+    $this->assertTrue($checkout->monthly_installments_enabled);
+    $this->assertEquals([3, 6, 12], (array) $checkout->monthly_installments_options);
 
     return $checkout;
   }

--- a/test/Conekta-2.0/CheckoutTest.php
+++ b/test/Conekta-2.0/CheckoutTest.php
@@ -28,6 +28,34 @@ class CheckoutTest extends BaseTest
         )
       )
     );
+
+  public static $validCheckoutWithMsi = array(
+    'name' => "Payment Link Name",
+    'type' => "PaymentLink",
+    'recurrent' => false,
+    'allowed_payment_methods' => array("cash", "card", "bank_transfer"),
+    'needs_shipping_contact' => false,
+    'monthly_installments_enabled' => true,
+    'monthly_installments_options' => [3,6,12],
+    'order_template' => array(
+      'line_items' => array(array(
+        'name' => "Red Wine",
+        'unit_price' => 30000,
+        'quantity' => 10
+      )),
+      'metadata' => array(
+        'mycustomkey' => "12345",
+        'othercustomkey' => "abcd"
+      ),
+      'currency' => "MXN",
+      'customer_info' => array(
+        'name' => "Juan Perez",
+        'email' => "juan.perez@conekta.com",
+        'phone' => "5566982090"
+      )
+    )
+  );
+
   public static $invalidCheckout = array(
     'names'  => 'John Constantine'
   );
@@ -41,6 +69,23 @@ class CheckoutTest extends BaseTest
     $this->assertTrue(strpos(get_class($checkout), 'Checkout') !== false);
     $this->assertEquals(false, $checkout->livemode);
     $this->assertEquals(self::$validCheckout['name'], $checkout->name);
+    $this->assertEquals(false, $checkout->needs_shipping_contact);
+    $this->assertStringStartsWith("https://pay.conekta", $checkout->url);
+    $this->assertStringEndsWith($checkout->slug, $checkout->url);
+    $this->assertTrue(strlen($checkout->id) == 36);
+
+    return $checkout;
+  }
+
+  public function testSuccesfulCheckoutCreateWithMSI()
+  {
+    $this->setApiKey();
+    self::$validCheckoutWithMsi['name'] = 'Payment Link Name ' . time();
+    self::$validCheckoutWithMsi['expired_at'] = static::getExpiredAt();
+    $checkout = Checkout::create(self::$validCheckoutWithMsi);
+    $this->assertTrue(strpos(get_class($checkout), 'Checkout') !== false);
+    $this->assertEquals(false, $checkout->livemode);
+    $this->assertEquals(self::$validCheckoutWithMsi['name'], $checkout->name);
     $this->assertEquals(false, $checkout->needs_shipping_contact);
     $this->assertStringStartsWith("https://pay.conekta", $checkout->url);
     $this->assertStringEndsWith($checkout->slug, $checkout->url);

--- a/test/Conekta-2.0/OrderTest.php
+++ b/test/Conekta-2.0/OrderTest.php
@@ -35,7 +35,6 @@ class OrderTest extends BaseTest
         )
       ),
       'checkout'    => array(
-        'multifactor_authentication' => false,
         'allowed_payment_methods' => array("cash", "card", "bank_transfer"),
         'monthly_installments_enabled' => true,
         'monthly_installments_options' => array(3, 6, 9, 12)
@@ -121,7 +120,6 @@ class OrderTest extends BaseTest
     $this->assertTrue(strpos(get_class($order), 'Order') !== false);
     $this->assertTrue(strpos(get_class($order->checkout), 'Checkout') !== false);
 
-    $this->assertEquals(false, $order->checkout->multifactor_authentication);
     $this->assertEquals(array("cash", "card", "bank_transfer"), (array) $order->checkout->allowed_payment_methods);
     $this->assertEquals(true, $order->checkout->monthly_installments_enabled);
     $this->assertEquals(array(3, 6, 9, 12), (array) $order->checkout->monthly_installments_options);

--- a/test/Conekta-2.0/TokenTest.php
+++ b/test/Conekta-2.0/TokenTest.php
@@ -17,7 +17,6 @@ class TokenTest extends BaseTest
     $this->assertTrue(strpos(get_class($token), 'Token') !== false);
     $this->assertTrue(strpos(get_class($token->checkout), 'Checkout') !== false);
 
-    $this->assertEquals(false, $token->checkout->multifactor_authentication);
     $this->assertEquals(array("card"), (array) $token->checkout->allowed_payment_methods);
     $this->assertEquals(false, $token->checkout->monthly_installments_enabled);
     $this->assertEquals(array(), (array) $token->checkout->monthly_installments_options);

--- a/test/Conekta-2.0/TokenTest.php
+++ b/test/Conekta-2.0/TokenTest.php
@@ -1,0 +1,29 @@
+<?php
+
+namespace Conekta;
+
+class TokenTest extends BaseTest
+{
+  public static $validTokenWithCheckout = array(
+      'checkout'    => array(
+        'returns_control_on' => 'Token'
+      ),
+    );
+
+  public function testSuccesfulCreateTokenWithCheckout()
+  {
+    $this->setApiKey();
+    $token = Token::create(self::$validTokenWithCheckout);
+    $this->assertTrue(strpos(get_class($token), 'Token') !== false);
+    $this->assertTrue(strpos(get_class($token->checkout), 'Checkout') !== false);
+
+    $this->assertEquals(false, $token->checkout->multifactor_authentication);
+    $this->assertEquals(array("card"), (array) $token->checkout->allowed_payment_methods);
+    $this->assertEquals(false, $token->checkout->monthly_installments_enabled);
+    $this->assertEquals(array(), (array) $token->checkout->monthly_installments_options);
+    $this->assertTrue( strlen($token->checkout->id) == 36);
+    $this->assertEquals('checkout', $token->checkout->object);
+    $this->assertEquals('Integration', $token->checkout->type);
+  }
+
+}


### PR DESCRIPTION
## Description
En un inicio se había pensado en un campo para habilitar / deshabilitar 3DS por link de pago/ order, esto actualmente ya no es asi, ya que existe configuración via  merchant.

## Changes proposed
Eliminar campo para multifactor_authenticator

## How to test it
Run phpunit tests

## Next steps
None.

## Deploy notes
None.
