### PR TITLE
feat: Add cancelPayoutOrderById method to PayoutOrdersApi

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,8 +50,13 @@ require_once(__DIR__ . '/vendor/autoload.php');
 
 
 
-// Configure Bearer authorization: bearerAuth
-$config = Conekta\Configuration::getDefaultConfiguration()->setAccessToken('YOUR_ACCESS_TOKEN');
+// Configure authorization
+/**
+ * @var string $apiKey use private key for authentication
+ * @link https://developers.conekta.com/reference/autenticaci%C3%B3n for more information
+ */
+$apiKey = "key_xxxxx";
+$config = Conekta\Configuration::getDefaultConfiguration()->setAccessToken($apiKey);
 
 
 $apiInstance = new Conekta\Api\AntifraudApi(
@@ -131,6 +136,7 @@ Class | Method | HTTP request | Description
 *PaymentMethodsApi* | [**deleteCustomerPaymentMethods**](docs/Api/PaymentMethodsApi.md#deletecustomerpaymentmethods) | **DELETE** /customers/{id}/payment_sources/{payment_method_id} | Delete Payment Method
 *PaymentMethodsApi* | [**getCustomerPaymentMethods**](docs/Api/PaymentMethodsApi.md#getcustomerpaymentmethods) | **GET** /customers/{id}/payment_sources | Get Payment Methods
 *PaymentMethodsApi* | [**updateCustomerPaymentMethods**](docs/Api/PaymentMethodsApi.md#updatecustomerpaymentmethods) | **PUT** /customers/{id}/payment_sources/{payment_method_id} | Update Payment Method
+*PayoutOrdersApi* | [**cancelPayoutOrderById**](docs/Api/PayoutOrdersApi.md#cancelpayoutorderbyid) | **PUT** /payout_orders/{id}/cancel | Cancel Payout Order
 *PayoutOrdersApi* | [**createPayoutOrder**](docs/Api/PayoutOrdersApi.md#createpayoutorder) | **POST** /payout_orders | Create payout order
 *PayoutOrdersApi* | [**getPayoutOrderById**](docs/Api/PayoutOrdersApi.md#getpayoutorderbyid) | **GET** /payout_orders/{id} | Get Payout Order
 *PayoutOrdersApi* | [**getPayoutOrders**](docs/Api/PayoutOrdersApi.md#getpayoutorders) | **GET** /payout_orders | Get a list of Payout Orders

--- a/docs/Api/PayoutOrdersApi.md
+++ b/docs/Api/PayoutOrdersApi.md
@@ -4,10 +4,73 @@ All URIs are relative to https://api.conekta.io, except if the operation defines
 
 | Method | HTTP request | Description |
 | ------------- | ------------- | ------------- |
+| [**cancelPayoutOrderById()**](PayoutOrdersApi.md#cancelPayoutOrderById) | **PUT** /payout_orders/{id}/cancel | Cancel Payout Order |
 | [**createPayoutOrder()**](PayoutOrdersApi.md#createPayoutOrder) | **POST** /payout_orders | Create payout order |
 | [**getPayoutOrderById()**](PayoutOrdersApi.md#getPayoutOrderById) | **GET** /payout_orders/{id} | Get Payout Order |
 | [**getPayoutOrders()**](PayoutOrdersApi.md#getPayoutOrders) | **GET** /payout_orders | Get a list of Payout Orders |
 
+
+## `cancelPayoutOrderById()`
+
+```php
+cancelPayoutOrderById($id, $accept_language): \Conekta\Model\PayoutOrderResponse
+```
+
+Cancel Payout Order
+
+Cancel a payout Order resource that corresponds to a payout order ID.
+
+### Example
+
+```php
+<?php
+require_once(__DIR__ . '/vendor/autoload.php');
+
+
+// Configure Bearer authorization: bearerAuth
+$config = Conekta\Configuration::getDefaultConfiguration()->setAccessToken('YOUR_ACCESS_TOKEN');
+
+
+$apiInstance = new Conekta\Api\PayoutOrdersApi(
+    // If you want use custom http client, pass your client which implements `GuzzleHttp\ClientInterface`.
+    // This is optional, `GuzzleHttp\Client` will be used as default.
+    new GuzzleHttp\Client(),
+    $config
+);
+$id = 6307a60c41de27127515a575; // string | Identifier of the resource
+$accept_language = es; // string | Use for knowing which language to use
+
+try {
+    $result = $apiInstance->cancelPayoutOrderById($id, $accept_language);
+    print_r($result);
+} catch (Exception $e) {
+    echo 'Exception when calling PayoutOrdersApi->cancelPayoutOrderById: ', $e->getMessage(), PHP_EOL;
+}
+```
+
+### Parameters
+
+| Name | Type | Description  | Notes |
+| ------------- | ------------- | ------------- | ------------- |
+| **id** | **string**| Identifier of the resource | |
+| **accept_language** | **string**| Use for knowing which language to use | [optional] [default to &#39;es&#39;] |
+
+### Return type
+
+[**\Conekta\Model\PayoutOrderResponse**](../Model/PayoutOrderResponse.md)
+
+### Authorization
+
+[bearerAuth](../../README.md#bearerAuth)
+
+### HTTP request headers
+
+- **Content-Type**: Not defined
+- **Accept**: `application/vnd.conekta-v2.1.0+json`
+
+[[Back to top]](#) [[Back to API list]](../../README.md#endpoints)
+[[Back to Model list]](../../README.md#models)
+[[Back to README]](../../README.md)
 
 ## `createPayoutOrder()`
 

--- a/lib/Api/PayoutOrdersApi.php
+++ b/lib/Api/PayoutOrdersApi.php
@@ -72,6 +72,9 @@ class PayoutOrdersApi
 
     /** @var string[] $contentTypes **/
     public const contentTypes = [
+        'cancelPayoutOrderById' => [
+            'application/json',
+        ],
         'createPayoutOrder' => [
             'application/json',
         ],
@@ -127,6 +130,436 @@ class PayoutOrdersApi
     public function getConfig()
     {
         return $this->config;
+    }
+
+    /**
+     * Operation cancelPayoutOrderById
+     *
+     * Cancel Payout Order
+     *
+     * @param  string $id Identifier of the resource (required)
+     * @param  string $accept_language Use for knowing which language to use (optional, default to 'es')
+     * @param  string $contentType The value for the Content-Type header. Check self::contentTypes['cancelPayoutOrderById'] to see the possible values for this operation
+     *
+     * @throws \Conekta\ApiException on non-2xx response or if the response body is not in the expected format
+     * @throws \InvalidArgumentException
+     * @return \Conekta\Model\PayoutOrderResponse|\Conekta\Model\Error|\Conekta\Model\Error|\Conekta\Model\Error
+     */
+    public function cancelPayoutOrderById($id, $accept_language = 'es', string $contentType = self::contentTypes['cancelPayoutOrderById'][0])
+    {
+        list($response) = $this->cancelPayoutOrderByIdWithHttpInfo($id, $accept_language, $contentType);
+        return $response;
+    }
+
+    /**
+     * Operation cancelPayoutOrderByIdWithHttpInfo
+     *
+     * Cancel Payout Order
+     *
+     * @param  string $id Identifier of the resource (required)
+     * @param  string $accept_language Use for knowing which language to use (optional, default to 'es')
+     * @param  string $contentType The value for the Content-Type header. Check self::contentTypes['cancelPayoutOrderById'] to see the possible values for this operation
+     *
+     * @throws \Conekta\ApiException on non-2xx response or if the response body is not in the expected format
+     * @throws \InvalidArgumentException
+     * @return array of \Conekta\Model\PayoutOrderResponse|\Conekta\Model\Error|\Conekta\Model\Error|\Conekta\Model\Error, HTTP status code, HTTP response headers (array of strings)
+     */
+    public function cancelPayoutOrderByIdWithHttpInfo($id, $accept_language = 'es', string $contentType = self::contentTypes['cancelPayoutOrderById'][0])
+    {
+        $request = $this->cancelPayoutOrderByIdRequest($id, $accept_language, $contentType);
+
+        try {
+            $options = $this->createHttpClientOption();
+            try {
+                $response = $this->client->send($request, $options);
+            } catch (RequestException $e) {
+                throw new ApiException(
+                    "[{$e->getCode()}] {$e->getMessage()}",
+                    (int) $e->getCode(),
+                    $e->getResponse() ? $e->getResponse()->getHeaders() : null,
+                    $e->getResponse() ? (string) $e->getResponse()->getBody() : null
+                );
+            } catch (ConnectException $e) {
+                throw new ApiException(
+                    "[{$e->getCode()}] {$e->getMessage()}",
+                    (int) $e->getCode(),
+                    null,
+                    null
+                );
+            }
+
+            $statusCode = $response->getStatusCode();
+
+            if ($statusCode < 200 || $statusCode > 299) {
+                throw new ApiException(
+                    sprintf(
+                        '[%d] Error connecting to the API (%s)',
+                        $statusCode,
+                        (string) $request->getUri()
+                    ),
+                    $statusCode,
+                    $response->getHeaders(),
+                    (string) $response->getBody()
+                );
+            }
+
+            switch($statusCode) {
+                case 200:
+                    if ('\Conekta\Model\PayoutOrderResponse' === '\SplFileObject') {
+                        $content = $response->getBody(); //stream goes to serializer
+                    } else {
+                        $content = (string) $response->getBody();
+                        if ('\Conekta\Model\PayoutOrderResponse' !== 'string') {
+                            try {
+                                $content = json_decode($content, false, 512, JSON_THROW_ON_ERROR);
+                            } catch (\JsonException $exception) {
+                                throw new ApiException(
+                                    sprintf(
+                                        'Error JSON decoding server response (%s)',
+                                        $request->getUri()
+                                    ),
+                                    $statusCode,
+                                    $response->getHeaders(),
+                                    $content
+                                );
+                            }
+                        }
+                    }
+
+                    return [
+                        ObjectSerializer::deserialize($content, '\Conekta\Model\PayoutOrderResponse', []),
+                        $response->getStatusCode(),
+                        $response->getHeaders()
+                    ];
+                case 401:
+                    if ('\Conekta\Model\Error' === '\SplFileObject') {
+                        $content = $response->getBody(); //stream goes to serializer
+                    } else {
+                        $content = (string) $response->getBody();
+                        if ('\Conekta\Model\Error' !== 'string') {
+                            try {
+                                $content = json_decode($content, false, 512, JSON_THROW_ON_ERROR);
+                            } catch (\JsonException $exception) {
+                                throw new ApiException(
+                                    sprintf(
+                                        'Error JSON decoding server response (%s)',
+                                        $request->getUri()
+                                    ),
+                                    $statusCode,
+                                    $response->getHeaders(),
+                                    $content
+                                );
+                            }
+                        }
+                    }
+
+                    return [
+                        ObjectSerializer::deserialize($content, '\Conekta\Model\Error', []),
+                        $response->getStatusCode(),
+                        $response->getHeaders()
+                    ];
+                case 404:
+                    if ('\Conekta\Model\Error' === '\SplFileObject') {
+                        $content = $response->getBody(); //stream goes to serializer
+                    } else {
+                        $content = (string) $response->getBody();
+                        if ('\Conekta\Model\Error' !== 'string') {
+                            try {
+                                $content = json_decode($content, false, 512, JSON_THROW_ON_ERROR);
+                            } catch (\JsonException $exception) {
+                                throw new ApiException(
+                                    sprintf(
+                                        'Error JSON decoding server response (%s)',
+                                        $request->getUri()
+                                    ),
+                                    $statusCode,
+                                    $response->getHeaders(),
+                                    $content
+                                );
+                            }
+                        }
+                    }
+
+                    return [
+                        ObjectSerializer::deserialize($content, '\Conekta\Model\Error', []),
+                        $response->getStatusCode(),
+                        $response->getHeaders()
+                    ];
+                case 500:
+                    if ('\Conekta\Model\Error' === '\SplFileObject') {
+                        $content = $response->getBody(); //stream goes to serializer
+                    } else {
+                        $content = (string) $response->getBody();
+                        if ('\Conekta\Model\Error' !== 'string') {
+                            try {
+                                $content = json_decode($content, false, 512, JSON_THROW_ON_ERROR);
+                            } catch (\JsonException $exception) {
+                                throw new ApiException(
+                                    sprintf(
+                                        'Error JSON decoding server response (%s)',
+                                        $request->getUri()
+                                    ),
+                                    $statusCode,
+                                    $response->getHeaders(),
+                                    $content
+                                );
+                            }
+                        }
+                    }
+
+                    return [
+                        ObjectSerializer::deserialize($content, '\Conekta\Model\Error', []),
+                        $response->getStatusCode(),
+                        $response->getHeaders()
+                    ];
+            }
+
+            $returnType = '\Conekta\Model\PayoutOrderResponse';
+            if ($returnType === '\SplFileObject') {
+                $content = $response->getBody(); //stream goes to serializer
+            } else {
+                $content = (string) $response->getBody();
+                if ($returnType !== 'string') {
+                    try {
+                        $content = json_decode($content, false, 512, JSON_THROW_ON_ERROR);
+                    } catch (\JsonException $exception) {
+                        throw new ApiException(
+                            sprintf(
+                                'Error JSON decoding server response (%s)',
+                                $request->getUri()
+                            ),
+                            $statusCode,
+                            $response->getHeaders(),
+                            $content
+                        );
+                    }
+                }
+            }
+
+            return [
+                ObjectSerializer::deserialize($content, $returnType, []),
+                $response->getStatusCode(),
+                $response->getHeaders()
+            ];
+
+        } catch (ApiException $e) {
+            switch ($e->getCode()) {
+                case 200:
+                    $data = ObjectSerializer::deserialize(
+                        $e->getResponseBody(),
+                        '\Conekta\Model\PayoutOrderResponse',
+                        $e->getResponseHeaders()
+                    );
+                    $e->setResponseObject($data);
+                    break;
+                case 401:
+                    $data = ObjectSerializer::deserialize(
+                        $e->getResponseBody(),
+                        '\Conekta\Model\Error',
+                        $e->getResponseHeaders()
+                    );
+                    $e->setResponseObject($data);
+                    break;
+                case 404:
+                    $data = ObjectSerializer::deserialize(
+                        $e->getResponseBody(),
+                        '\Conekta\Model\Error',
+                        $e->getResponseHeaders()
+                    );
+                    $e->setResponseObject($data);
+                    break;
+                case 500:
+                    $data = ObjectSerializer::deserialize(
+                        $e->getResponseBody(),
+                        '\Conekta\Model\Error',
+                        $e->getResponseHeaders()
+                    );
+                    $e->setResponseObject($data);
+                    break;
+            }
+            throw $e;
+        }
+    }
+
+    /**
+     * Operation cancelPayoutOrderByIdAsync
+     *
+     * Cancel Payout Order
+     *
+     * @param  string $id Identifier of the resource (required)
+     * @param  string $accept_language Use for knowing which language to use (optional, default to 'es')
+     * @param  string $contentType The value for the Content-Type header. Check self::contentTypes['cancelPayoutOrderById'] to see the possible values for this operation
+     *
+     * @throws \InvalidArgumentException
+     * @return \GuzzleHttp\Promise\PromiseInterface
+     */
+    public function cancelPayoutOrderByIdAsync($id, $accept_language = 'es', string $contentType = self::contentTypes['cancelPayoutOrderById'][0])
+    {
+        return $this->cancelPayoutOrderByIdAsyncWithHttpInfo($id, $accept_language, $contentType)
+            ->then(
+                function ($response) {
+                    return $response[0];
+                }
+            );
+    }
+
+    /**
+     * Operation cancelPayoutOrderByIdAsyncWithHttpInfo
+     *
+     * Cancel Payout Order
+     *
+     * @param  string $id Identifier of the resource (required)
+     * @param  string $accept_language Use for knowing which language to use (optional, default to 'es')
+     * @param  string $contentType The value for the Content-Type header. Check self::contentTypes['cancelPayoutOrderById'] to see the possible values for this operation
+     *
+     * @throws \InvalidArgumentException
+     * @return \GuzzleHttp\Promise\PromiseInterface
+     */
+    public function cancelPayoutOrderByIdAsyncWithHttpInfo($id, $accept_language = 'es', string $contentType = self::contentTypes['cancelPayoutOrderById'][0])
+    {
+        $returnType = '\Conekta\Model\PayoutOrderResponse';
+        $request = $this->cancelPayoutOrderByIdRequest($id, $accept_language, $contentType);
+
+        return $this->client
+            ->sendAsync($request, $this->createHttpClientOption())
+            ->then(
+                function ($response) use ($returnType) {
+                    if ($returnType === '\SplFileObject') {
+                        $content = $response->getBody(); //stream goes to serializer
+                    } else {
+                        $content = (string) $response->getBody();
+                        if ($returnType !== 'string') {
+                            $content = json_decode($content);
+                        }
+                    }
+
+                    return [
+                        ObjectSerializer::deserialize($content, $returnType, []),
+                        $response->getStatusCode(),
+                        $response->getHeaders()
+                    ];
+                },
+                function ($exception) {
+                    $response = $exception->getResponse();
+                    $statusCode = $response->getStatusCode();
+                    throw new ApiException(
+                        sprintf(
+                            '[%d] Error connecting to the API (%s)',
+                            $statusCode,
+                            $exception->getRequest()->getUri()
+                        ),
+                        $statusCode,
+                        $response->getHeaders(),
+                        (string) $response->getBody()
+                    );
+                }
+            );
+    }
+
+    /**
+     * Create request for operation 'cancelPayoutOrderById'
+     *
+     * @param  string $id Identifier of the resource (required)
+     * @param  string $accept_language Use for knowing which language to use (optional, default to 'es')
+     * @param  string $contentType The value for the Content-Type header. Check self::contentTypes['cancelPayoutOrderById'] to see the possible values for this operation
+     *
+     * @throws \InvalidArgumentException
+     * @return \GuzzleHttp\Psr7\Request
+     */
+    public function cancelPayoutOrderByIdRequest($id, $accept_language = 'es', string $contentType = self::contentTypes['cancelPayoutOrderById'][0])
+    {
+
+        // verify the required parameter 'id' is set
+        if ($id === null || (is_array($id) && count($id) === 0)) {
+            throw new \InvalidArgumentException(
+                'Missing the required parameter $id when calling cancelPayoutOrderById'
+            );
+        }
+
+
+
+        $resourcePath = '/payout_orders/{id}/cancel';
+        $formParams = [];
+        $queryParams = [];
+        $headerParams = [];
+        $httpBody = '';
+        $multipart = false;
+
+
+        // header params
+        if ($accept_language !== null) {
+            $headerParams['Accept-Language'] = ObjectSerializer::toHeaderValue($accept_language);
+        }
+
+        // path params
+        if ($id !== null) {
+            $resourcePath = str_replace(
+                '{' . 'id' . '}',
+                ObjectSerializer::toPathValue($id),
+                $resourcePath
+            );
+        }
+
+
+        $headers = $this->headerSelector->selectHeaders(
+            ['application/vnd.conekta-v2.1.0+json', ],
+            $contentType,
+            $multipart
+        );
+        $headers = array_merge(
+            $this->headerSelector->getConektaUserAgent(),
+            $headers
+        );
+
+        // for model (json/xml)
+        if (count($formParams) > 0) {
+            if ($multipart) {
+                $multipartContents = [];
+                foreach ($formParams as $formParamName => $formParamValue) {
+                    $formParamValueItems = is_array($formParamValue) ? $formParamValue : [$formParamValue];
+                    foreach ($formParamValueItems as $formParamValueItem) {
+                        $multipartContents[] = [
+                            'name' => $formParamName,
+                            'contents' => $formParamValueItem
+                        ];
+                    }
+                }
+                // for HTTP post (form)
+                $httpBody = new MultipartStream($multipartContents);
+
+            } elseif (stripos($headers['Content-Type'], 'application/json') !== false) {
+                # if Content-Type contains "application/json", json_encode the form parameters
+                $httpBody = \GuzzleHttp\Utils::jsonEncode($formParams);
+            } else {
+                // for HTTP post (form)
+                $httpBody = ObjectSerializer::buildQuery($formParams);
+            }
+        }
+
+        // this endpoint requires Bearer authentication (access token)
+        if (!empty($this->config->getAccessToken())) {
+            $headers['Authorization'] = 'Bearer ' . $this->config->getAccessToken();
+        }
+
+        $defaultHeaders = [];
+        if ($this->config->getUserAgent()) {
+            $defaultHeaders['User-Agent'] = $this->config->getUserAgent();
+        }
+
+        $headers = array_merge(
+            $defaultHeaders,
+            $headerParams,
+            $headers
+        );
+
+        $operationHost = $this->config->getHost();
+        $query = ObjectSerializer::buildQuery($queryParams);
+        return new Request(
+            'PUT',
+            $operationHost . $resourcePath . ($query ? "?{$query}" : ''),
+            $headers,
+            $httpBody
+        );
     }
 
     /**

--- a/lib/Model/OrderResponseCheckout.php
+++ b/lib/Model/OrderResponseCheckout.php
@@ -142,7 +142,7 @@ class OrderResponseCheckout implements ModelInterface, ArrayAccess, \JsonSeriali
         'id' => false,
         'is_redirect_on_failure' => false,
         'livemode' => false,
-        'max_failed_retries' => false,
+        'max_failed_retries' => true,
         'metadata' => false,
         'monthly_installments_enabled' => false,
         'monthly_installments_options' => false,
@@ -773,7 +773,14 @@ class OrderResponseCheckout implements ModelInterface, ArrayAccess, \JsonSeriali
     public function setMaxFailedRetries($max_failed_retries)
     {
         if (is_null($max_failed_retries)) {
-            throw new \InvalidArgumentException('non-nullable max_failed_retries cannot be null');
+            array_push($this->openAPINullablesSetToNull, 'max_failed_retries');
+        } else {
+            $nullablesSetToNull = $this->getOpenAPINullablesSetToNull();
+            $index = array_search('max_failed_retries', $nullablesSetToNull);
+            if ($index !== FALSE) {
+                unset($nullablesSetToNull[$index]);
+                $this->setOpenAPINullablesSetToNull($nullablesSetToNull);
+            }
         }
         $this->container['max_failed_retries'] = $max_failed_retries;
 


### PR DESCRIPTION
This commit adds the `cancelPayoutOrderById()` method to the `PayoutOrdersApi` class. This method allows users to cancel a payout order by providing the ID of the resource. The method sends a PUT request to the server with the necessary parameters and returns a `PayoutOrderResponse` object if successful.
