### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/build_test.yml
+++ b/.github/workflows/build_test.yml
@@ -1,4 +1,6 @@
 name: CI
+permissions:
+  contents: read
 on:
   push:
     branches: [master]


### PR DESCRIPTION
Potential fix for [https://github.com/conekta/conekta-php/security/code-scanning/1](https://github.com/conekta/conekta-php/security/code-scanning/1)

In general, fix this by explicitly specifying a least-privilege `permissions:` block either at the top level of the workflow (applies to all jobs) or within the specific job. Since this workflow only checks out code and runs tests, it likely only needs read access to repository contents, so `contents: read` is sufficient as a secure baseline.

The best fix without changing existing functionality is to add a root-level `permissions:` section right under the `name: CI` line in `.github/workflows/build_test.yml`. This ensures all jobs (currently just `phpunit`) inherit `contents: read` for the `GITHUB_TOKEN`. No other scopes (issues, pull-requests, etc.) are required by any of the shown steps, and third-party actions used here (checkout, setup-php, composer-install, phpstan, mockoon CLI) function correctly with read-only contents access. No additional imports, methods, or definitions are needed since this is a YAML configuration-only change.

Concretely:
- Edit `.github/workflows/build_test.yml`.
- Between line 1 (`name: CI`) and line 2 (`on:`), insert:

```yaml
permissions:
  contents: read
```

This satisfies CodeQL’s recommendation and limits the token to the minimum required.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Sets least-privilege `permissions` for the CI workflow to address a code scanning alert and constrain the `GITHUB_TOKEN`.
> 
> - Adds root-level `permissions:
>   contents: read` in `.github/workflows/build_test.yml` so all jobs inherit read-only access
> - No changes to jobs, steps, or behavior beyond token scope restriction
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit d645c07e5a6b6bef47956a71464c64fe2dd7874b. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->